### PR TITLE
Unity server update

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,13 +1,176 @@
-Copyright 2020 Unity Technologies
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-    http://www.apache.org/licenses/LICENSE-2.0
+   1. Definitions.
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/tcp_endpoint/CMakeLists.txt
+++ b/tcp_endpoint/CMakeLists.txt
@@ -11,6 +11,7 @@ find_package(catkin REQUIRED COMPONENTS
   roscpp
   rospy
   std_msgs
+  message_generation
 )
 
 ## System dependencies are found with CMake's conventions
@@ -47,18 +48,16 @@ catkin_python_setup()
 ##   * add every package in MSG_DEP_SET to generate_messages(DEPENDENCIES ...)
 
 ## Generate messages in the 'msg' folder
-# add_message_files(
-#   FILES
-#   Message1.msg
-#   Message2.msg
-# )
+add_message_files(
+  FILES
+  RosUnityError.msg
+)
 
 ## Generate services in the 'srv' folder
-# add_service_files(
-#   FILES
-#   Service1.srv
-#   Service2.srv
-# )
+add_service_files(
+  FILES
+  RosUnityHandshake.srv
+)
 
 ## Generate actions in the 'action' folder
 # add_action_files(
@@ -68,10 +67,10 @@ catkin_python_setup()
 # )
 
 ## Generate added messages and services with any dependencies listed here
-# generate_messages(
-#   DEPENDENCIES
-#   std_msgs
-# )
+generate_messages(
+  DEPENDENCIES
+  std_msgs
+)
 
 ################################################
 ## Declare ROS dynamic reconfigure parameters ##
@@ -106,6 +105,7 @@ catkin_package(
 #  INCLUDE_DIRS include
 #  LIBRARIES tcp_endpoint
 #  CATKIN_DEPENDS roscpp rospy std_msgs
+CATKIN_DEPENDS message_runtime
 #  DEPENDS system_lib
 )
 

--- a/tcp_endpoint/msg/RosUnityError.msg
+++ b/tcp_endpoint/msg/RosUnityError.msg
@@ -1,0 +1,1 @@
+string message

--- a/tcp_endpoint/package.xml
+++ b/tcp_endpoint/package.xml
@@ -43,7 +43,7 @@
   <!-- Use buildtool_depend for build tool packages: -->
   <!--   <buildtool_depend>catkin</buildtool_depend> -->
   <!-- Use exec_depend for packages you need at runtime: -->
-  <!--   <exec_depend>message_runtime</exec_depend> -->
+     <exec_depend>message_runtime</exec_depend>
   <!-- Use test_depend for packages you need only for testing: -->
   <!--   <test_depend>gtest</test_depend> -->
   <!-- Use doc_depend for packages you need only for building documentation: -->

--- a/tcp_endpoint/src/tcp_endpoint/RosSubscriber.py
+++ b/tcp_endpoint/src/tcp_endpoint/RosSubscriber.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-import StringIO
 
 import rospy
 import socket
@@ -13,7 +12,7 @@ class RosSubscriber(RosReceiver):
     Class to send messages outside of ROS network
     """
 
-    def __init__(self, topic, message_class, tcp_sender, queue_size=10):
+    def __init__(self, topic, message_class, tcp_server, queue_size=10):
         """
 
         Args:
@@ -24,7 +23,7 @@ class RosSubscriber(RosReceiver):
         self.topic = topic
         self.node_name = "{}_subsciber".format(topic)
         self.msg = message_class
-        self.tcp_sender = tcp_sender
+        self.tcp_server = tcp_server
         self.queue_size = queue_size
 
         # Start Subscriber listener function
@@ -41,7 +40,7 @@ class RosSubscriber(RosReceiver):
 
         """
 
-        self.tcp_sender.send_unity_message(self.topic, data)
+        self.tcp_server.send_unity_message(self.topic, data)
         return self.msg
 
     def listener(self):

--- a/tcp_endpoint/src/tcp_endpoint/RosSubscriber.py
+++ b/tcp_endpoint/src/tcp_endpoint/RosSubscriber.py
@@ -13,7 +13,7 @@ class RosSubscriber(RosReceiver):
     Class to send messages outside of ROS network
     """
 
-    def __init__(self, topic, message_class, server_ip, server_port, queue_size=10):
+    def __init__(self, topic, message_class, tcp_sender, queue_size=10):
         """
 
         Args:
@@ -24,8 +24,7 @@ class RosSubscriber(RosReceiver):
         self.topic = topic
         self.node_name = "{}_subsciber".format(topic)
         self.msg = message_class
-        self.tcp_id = server_ip
-        self.tcp_port = server_port
+        self.tcp_sender = tcp_sender
         self.queue_size = queue_size
 
         # Start Subscriber listener function
@@ -42,16 +41,7 @@ class RosSubscriber(RosReceiver):
 
         """
 
-        serialized_message = ClientThread.serialize_message(self.topic, data)
-
-        try:
-            s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            s.connect((self.tcp_id, self.tcp_port))
-            s.send(serialized_message)
-            s.close()
-        except Exception as e:
-            rospy.loginfo("Exception {}".format(e))
-
+        self.tcp_sender.send_unity_message(self.topic, data)
         return self.msg
 
     def listener(self):

--- a/tcp_endpoint/src/tcp_endpoint/RosTCPClientThread.py
+++ b/tcp_endpoint/src/tcp_endpoint/RosTCPClientThread.py
@@ -142,7 +142,6 @@ class ClientThread(Thread):
                 raise TopicOrServiceNameDoesNotExistError(error_msg)
             else:
                 ros_communicator = self.tcp_server.special_destination_dict[destination]
-                # this feels pretty hacky...
                 ros_communicator.set_thread(self)
         elif destination not in self.tcp_server.source_destination_dict.keys():
             error_msg = "Topic/service destination '{}' is not defined! Known topics are: {} "\

--- a/tcp_endpoint/src/tcp_endpoint/RosTCPClientThread.py
+++ b/tcp_endpoint/src/tcp_endpoint/RosTCPClientThread.py
@@ -142,7 +142,7 @@ class ClientThread(Thread):
                 raise TopicOrServiceNameDoesNotExistError(error_msg)
             else:
                 ros_communicator = self.tcp_server.special_destination_dict[destination]
-                ros_communicator.set_thread(self)
+                ros_communicator.set_incoming_ip(self.incoming_ip)
         elif destination not in self.tcp_server.source_destination_dict.keys():
             error_msg = "Topic/service destination '{}' is not defined! Known topics are: {} "\
                 .format(destination, self.tcp_server.source_destination_dict.keys())

--- a/tcp_endpoint/src/tcp_endpoint/RosTCPClientThread.py
+++ b/tcp_endpoint/src/tcp_endpoint/RosTCPClientThread.py
@@ -1,19 +1,20 @@
 #!/usr/bin/env python
 
 import struct
+import socket
+import rospy
 from io import BytesIO
 
 from threading import Thread
 
 from tcp_endpoint.TCPEndpointExceptions import TopicOrServiceNameDoesNotExistError
 
-
 class ClientThread(Thread):
     """
     Thread class to read all data from a connection and pass along the data to the
     desired source.
     """
-    def __init__(self, conn, source_destination_dict):
+    def __init__(self, conn, tcp_server, incoming_ip, incoming_port):
         """
         Set class variables
         Args:
@@ -22,7 +23,9 @@ class ClientThread(Thread):
         """
         Thread.__init__(self)
         self.conn = conn
-        self.source_destination_dict = source_destination_dict
+        self.tcp_server = tcp_server
+        self.incoming_ip = incoming_ip
+        self.incoming_port = incoming_port
 
     def read_int32(self):
         """
@@ -130,14 +133,27 @@ class ClientThread(Thread):
             print("No data for a message size of {}, breaking!".format(full_message_size))
             return
 
-        if destination not in self.source_destination_dict.keys():
-            error_msg = "Topic/Service destination '{}' does not exist in source destination dictionary {} "\
-                .format(destination, self.source_destination_dict.keys())
+        if destination.startswith('__'):
+            if destination not in self.tcp_server.special_destination_dict.keys():
+                error_msg = "System message '{}' is undefined! Known system calls are: {}"\
+                    .format(destination, self.tcp_server.special_destination_dict.keys())
+                self.conn.close()
+                self.tcp_server.send_unity_error(error_msg)
+                raise TopicOrServiceNameDoesNotExistError(error_msg)
+            else:
+                ros_communicator = self.tcp_server.special_destination_dict[destination]
+                # this feels pretty hacky...
+                ros_communicator.set_thread(self)
+        elif destination not in self.tcp_server.source_destination_dict.keys():
+            error_msg = "Topic/service destination '{}' is not defined! Known topics are: {} "\
+                .format(destination, self.tcp_server.source_destination_dict.keys())
             self.conn.close()
+            self.tcp_server.send_unity_error(error_msg)
             raise TopicOrServiceNameDoesNotExistError(error_msg)
+        else:
+            ros_communicator = self.tcp_server.source_destination_dict[destination]
 
         try:
-            ros_communicator = self.source_destination_dict[destination]
             response = ros_communicator.send(data)
 
             # Responses only exist for services

--- a/tcp_endpoint/src/tcp_endpoint/RosTCPServer.py
+++ b/tcp_endpoint/src/tcp_endpoint/RosTCPServer.py
@@ -3,6 +3,7 @@
 import rospy
 import socket
 
+from tcp_endpoint.UnityTCPSender import UnityTCPSender
 from tcp_endpoint.RosTCPClientThread import ClientThread
 from tcp_endpoint.RosUnityHandshakeService import RosUnityHandshakeService
 
@@ -11,7 +12,7 @@ class TCPServer:
     Initializes ROS node and TCP server.
     """
 
-    def __init__(self, tcp_ip, tcp_port, unity_tcp_sender, node_name, source_destination_dict, buffer_size=1024, connections=10):
+    def __init__(self, node_name, buffer_size=1024, connections=10):
         """
         Initializes ROS node and class variables.
 
@@ -23,13 +24,17 @@ class TCPServer:
             buffer_size:             The read buffer size used when reading from a socket
             connections:             Max number of queued connections. See Python Socket documentation
         """
-        self.tcp_ip = tcp_ip
-        self.tcp_port = tcp_port
-        self.unity_tcp_sender = unity_tcp_sender
+        self.tcp_ip = rospy.get_param("/ROS_IP")
+        self.tcp_port = rospy.get_param("/ROS_TCP_PORT", 10000)
+
+        unity_machine_ip = rospy.get_param("/UNITY_IP", '')
+        unity_machine_port = rospy.get_param("/UNITY_SERVER_PORT", 5005)
+        self.unity_tcp_sender = UnityTCPSender(unity_machine_ip, unity_machine_port)
+
         self.node_name = node_name
-        self.source_destination_dict = source_destination_dict
+        self.source_destination_dict = {}
         self.special_destination_dict = {
-            '__handshake': RosUnityHandshakeService(unity_tcp_sender)
+            '__handshake': RosUnityHandshakeService(self.unity_tcp_sender)
         }
         self.buffer_size = buffer_size
         self.connections = connections
@@ -58,3 +63,6 @@ class TCPServer:
 
     def send_unity_error(self, error):
         self.unity_tcp_sender.send_unity_error(error)
+
+    def send_unity_message(self, topic, message):
+        self.unity_tcp_sender.send_unity_message(topic, message)

--- a/tcp_endpoint/src/tcp_endpoint/RosUnityHandshakeService.py
+++ b/tcp_endpoint/src/tcp_endpoint/RosUnityHandshakeService.py
@@ -17,8 +17,8 @@ class RosUnityHandshakeService:
         self.incoming_ip = ''
 
     # The client thread lets us know what the incoming IP is, so we can use it later
-    def set_thread(self, tcp_client_thread):
-        self.incoming_ip = tcp_client_thread.incoming_ip
+    def set_incoming_ip(self, ip):
+        self.incoming_ip = ip
 
     def send(self, data):
         message = self.srv_class.deserialize(data)

--- a/tcp_endpoint/src/tcp_endpoint/RosUnityHandshakeService.py
+++ b/tcp_endpoint/src/tcp_endpoint/RosUnityHandshakeService.py
@@ -5,13 +5,12 @@ from tcp_endpoint.srv import RosUnityHandshake, RosUnityHandshakeResponse
 
 class RosUnityHandshakeService:
     """
-    Class to handle system messages.
+    Class to auto-detect Unity IP.
     """
     def __init__(self, tcp_sender):
         """
         Args:
-            service:        The service name in ROS
-            service_class:  The service class in catkin workspace
+            tcp_sender:     sends messages to Unity
         """
         self.srv_class = RosUnityHandshake._request_class()
         self.tcp_sender = tcp_sender

--- a/tcp_endpoint/src/tcp_endpoint/RosUnityHandshakeService.py
+++ b/tcp_endpoint/src/tcp_endpoint/RosUnityHandshakeService.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+
+import rospy
+from tcp_endpoint.srv import RosUnityHandshake, RosUnityHandshakeResponse
+
+class RosUnityHandshakeService:
+    """
+    Class to handle system messages.
+    """
+    def __init__(self, tcp_sender):
+        """
+        Args:
+            service:        The service name in ROS
+            service_class:  The service class in catkin workspace
+        """
+        self.srv_class = RosUnityHandshake._request_class()
+        self.tcp_sender = tcp_sender
+        self.incoming_ip = ''
+
+    def set_thread(self, tcp_client_thread):
+        self.incoming_ip = tcp_client_thread.incoming_ip
+
+    def send(self, data):
+        message = self.srv_class.deserialize(data)
+        if message.ip == '':
+            self.tcp_sender.process_handshake(self.incoming_ip, message.port)
+        else:
+            self.tcp_sender.process_handshake(message.ip, message.port)
+        return RosUnityHandshakeResponse(self.tcp_sender.unity_ip)

--- a/tcp_endpoint/src/tcp_endpoint/UnityTCPSender.py
+++ b/tcp_endpoint/src/tcp_endpoint/UnityTCPSender.py
@@ -1,0 +1,40 @@
+import rospy
+import socket
+from tcp_endpoint.RosTCPClientThread import ClientThread
+from tcp_endpoint.msg import RosUnityError
+
+class UnityTCPSender:
+    """
+    Connects and sends messages to the server on the Unity side.
+    """
+    def __init__(self, unity_ip, unity_port):
+        self.unity_ip = unity_ip
+        self.unity_port = unity_port
+        self.ip_is_overridden = (self.unity_ip != '')
+
+    def process_handshake(self, ip, port):
+        self.unity_port = port
+        if ip != '' and not self.ip_is_overridden:
+            self.unity_ip = ip
+        print("ROS-Unity Handshake received, will connect to {}:{}".format(self.unity_ip, self.unity_port))
+
+    def send_unity_error(self, error):
+        self.send_unity_message("__error", RosUnityError(error))
+
+    def send_unity_message(self, topic, message):
+        if self.unity_ip == '':
+            print("Can't send a message, no defined unity IP!".format(topic, message))
+            return
+
+        serialized_message = ClientThread.serialize_message(topic, message)
+
+        try:
+            s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            s.settimeout(2)
+            s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            s.connect((self.unity_ip, self.unity_port))
+            s.send(serialized_message)
+            s.close()
+        except Exception as e:
+            rospy.loginfo("Exception {}".format(e))
+            # print("Failed to send unity message {} {} to {}:{}".format(topic, message, self.unity_ip, self.unity_port))

--- a/tcp_endpoint/srv/RosUnityHandshake.srv
+++ b/tcp_endpoint/srv/RosUnityHandshake.srv
@@ -1,0 +1,4 @@
+string ip
+uint16 port
+---
+string ip


### PR DESCRIPTION
Created a single Unity-side listen server in ROSConnection.
* ROS gets notified of Unity's IP automatically: the UNITY_IP setting is no longer required (but is still supported for overriding the IP, in case someone has a weird setup).
* ROS can send error messages to the Unity console.
* RosSubscriber no longer exists, now user-written subscriber scripts simply Listen to a topic on ROSConnection. (Previously, we couldn't handle more than one RosSubscriber, since ROS only knew about one Unity port; each subscriber would have had to listen on the same port.)
* Tutorials updated accordingly

Tested by going through the ROS-Unity Integration and the Pick & Place tutorial.