### PR TITLE
Enable the server to keep the connection to the client

### DIFF
--- a/tcp_endpoint/CMakeLists.txt
+++ b/tcp_endpoint/CMakeLists.txt
@@ -51,6 +51,7 @@ catkin_python_setup()
 add_message_files(
   FILES
   RosUnityError.msg
+  RosUnityConnectionParam.msg
 )
 
 ## Generate services in the 'srv' folder

--- a/tcp_endpoint/msg/RosUnityConnectionParam.msg
+++ b/tcp_endpoint/msg/RosUnityConnectionParam.msg
@@ -1,0 +1,1 @@
+bool keepConnectionOpen

--- a/tcp_endpoint/src/tcp_endpoint/RosTCPClientThread.py
+++ b/tcp_endpoint/src/tcp_endpoint/RosTCPClientThread.py
@@ -124,12 +124,11 @@ class ClientThread(Thread):
             try:
                 response = self.conn.send("")
             except Exception as e:
+                self.conn.close()
                 print("Connection closed ? Exception Raised: {}".format(e))
                 return
             
             data = b''
-
-           
 
             destination = self.read_string()
             full_message_size = self.read_int32()
@@ -149,6 +148,7 @@ class ClientThread(Thread):
 
             if not data:
                 print("No data for a message size of {}, breaking!".format(full_message_size))
+                self.conn.close()
                 return
 
             if destination.startswith('__'):

--- a/tcp_endpoint/src/tcp_endpoint/RosTCPClientThread.py
+++ b/tcp_endpoint/src/tcp_endpoint/RosTCPClientThread.py
@@ -170,6 +170,7 @@ class ClientThread(Thread):
             if destination == '__connection_param':
                 parameters = RosUnityConnectionParam().deserialize(data)
                 self.keep_connection_open = parameters.keepConnectionOpen
+                self.tcp_server.set_keep_connection(parameters.keepConnectionOpen)
                 print("Received connection parameters. Will keep connection Opened ? : {}".format(self.keep_connection_open))
                 continue
             elif destination.startswith('__'):

--- a/tcp_endpoint/src/tcp_endpoint/RosTCPClientThread.py
+++ b/tcp_endpoint/src/tcp_endpoint/RosTCPClientThread.py
@@ -144,6 +144,10 @@ class ClientThread(Thread):
             data = b''
 
             destination = self.read_string()
+            if not destination:
+                print("No destination...")
+                break
+
             full_message_size = self.read_int32()
 
             while len(data) < full_message_size:

--- a/tcp_endpoint/src/tcp_endpoint/RosTCPServer.py
+++ b/tcp_endpoint/src/tcp_endpoint/RosTCPServer.py
@@ -61,6 +61,9 @@ class TCPServer:
         for t in threads:
             t.join()
 
+    def set_keep_connection(self, value):
+        self.unity_tcp_sender.keep_connection_open = value
+
     def send_unity_error(self, error):
         self.unity_tcp_sender.send_unity_error(error)
 

--- a/tcp_endpoint/src/tcp_endpoint/UnityTCPSender.py
+++ b/tcp_endpoint/src/tcp_endpoint/UnityTCPSender.py
@@ -37,6 +37,7 @@ class UnityTCPSender:
                 s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
                 s.connect((self.unity_ip, self.unity_port))
                 if self.keep_connection_open:
+                    rospy.loginfo("Opening unique subscriber connection")
                     self.socket = s
                 s.send(serialized_message)
             else:

--- a/tcp_endpoint/src/tcp_endpoint/UnityTCPSender.py
+++ b/tcp_endpoint/src/tcp_endpoint/UnityTCPSender.py
@@ -12,6 +12,8 @@ class UnityTCPSender:
         self.unity_port = unity_port
         # if we have a valid IP at this point, it was overridden locally so always use that
         self.ip_is_overridden = (self.unity_ip != '')
+        self.keep_connection_open = False
+        self.socket = None
 
     def process_handshake(self, ip, port):
         self.unity_port = port
@@ -28,13 +30,21 @@ class UnityTCPSender:
             return
 
         serialized_message = ClientThread.serialize_message(topic, message)
-
         try:
-            s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            s.settimeout(2)
-            s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-            s.connect((self.unity_ip, self.unity_port))
-            s.send(serialized_message)
-            s.close()
+            if not self.keep_connection_open or self.socket == None:
+                s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                s.settimeout(2)
+                s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+                s.connect((self.unity_ip, self.unity_port))
+                if self.keep_connection_open:
+                    self.socket = s
+                s.send(serialized_message)
+            else:
+                self.socket.send(serialized_message)
+            if not self.keep_connection_open:
+                s.close()
         except Exception as e:
+            if self.socket != None:
+                self.socket.close()
+                self.socket = None
             rospy.loginfo("Exception {}".format(e))


### PR DESCRIPTION
So far, the server and clients create a new connection for each new message which takes time (almost as much as sending the message).
This PR allows the tcpclient to receive a special message (connection parameters) that tells it to keep the connection open (default is not to keep the connection open, to keep the previous behaviour)

I will create the corresponding PR on the connector if this one is accepted