### PR TITLE
RegisterSubscriber bugfix

### DIFF
--- a/src/ros_tcp_endpoint/publisher.py
+++ b/src/ros_tcp_endpoint/publisher.py
@@ -49,3 +49,11 @@ class RosPublisher(RosSender):
         self.pub.publish(self.msg)
 
         return None
+
+    def unregister(self):
+        """
+
+        Returns:
+
+        """
+        self.pub.unregister()

--- a/src/ros_tcp_endpoint/server.py
+++ b/src/ros_tcp_endpoint/server.py
@@ -105,7 +105,11 @@ class SysCommands:
             self.tcp_server.send_unity_error("SysCommand.subscribe - Unknown message class '{}'".format(message_name))
             return
 
-        print("RegisterSubscriber({}, {}) OK".format(topic, message_class))
+        rospy.loginfo("RegisterSubscriber({}, {}) OK".format(topic, message_class))
+        
+        if topic in self.tcp_server.source_destination_dict:
+            self.tcp_server.source_destination_dict[topic].unregister()
+
         self.tcp_server.source_destination_dict[topic] = RosSubscriber(topic, message_class, self.tcp_server)
 
     def publish(self, topic, message_name):
@@ -119,7 +123,11 @@ class SysCommands:
             self.tcp_server.send_unity_error("SysCommand.publish - Unknown message class '{}'".format(message_name))
             return
 
-        print("RegisterPublisher({}, {}) OK".format(topic, message_class))
+        rospy.loginfo("RegisterPublisher({}, {}) OK".format(topic, message_class))
+        
+        if topic in self.tcp_server.source_destination_dict:
+            self.tcp_server.source_destination_dict[topic].unregister()
+        
         self.tcp_server.source_destination_dict[topic] = RosPublisher(topic, message_class, queue_size=10)
 
 
@@ -130,13 +138,13 @@ def resolve_message_name(name):
         class_name = names[1]
         module = sys.modules[module_name]
         if module is None:
-            print("Failed to resolve module {}".format(module_name))
+            rospy.loginfo("Failed to resolve module {}".format(module_name))
         module = getattr(module, 'msg')
         if module is None:
-            print("Failed to resolve module {}.msg".format(module_name))
+            rospy.loginfo("Failed to resolve module {}.msg".format(module_name))
         module = getattr(module, class_name)
         if module is None:
-            print("Failed to resolve module {}.msg.{}".format(module_name, class_name))
+            rospy.loginfo("Failed to resolve module {}.msg.{}".format(module_name, class_name))
         return module
     except (IndexError, KeyError, AttributeError) as e:
         return None

--- a/src/ros_tcp_endpoint/service.py
+++ b/src/ros_tcp_endpoint/service.py
@@ -59,3 +59,12 @@ class RosService(RosSender):
                 print("Exception Raised: {}".format(e))
 
         return None
+
+    def unregister(self):
+        """
+
+        Returns:
+
+        """
+        if not self.srv is None:
+            self.srv.close()

--- a/src/ros_tcp_endpoint/subscriber.py
+++ b/src/ros_tcp_endpoint/subscriber.py
@@ -39,7 +39,7 @@ class RosSubscriber(RosReceiver):
         self.queue_size = queue_size
 
         # Start Subscriber listener function
-        self.listener()
+        self.sub = rospy.Subscriber(self.topic, self.msg, self.send)
 
     def send(self, data):
         """
@@ -55,10 +55,11 @@ class RosSubscriber(RosReceiver):
         self.tcp_server.send_unity_message(self.topic, data)
         return self.msg
 
-    def listener(self):
+    def unregister(self):
         """
 
         Returns:
 
         """
-        rospy.Subscriber(self.topic, self.msg, self.send)
+        if not self.sub is None:
+            self.sub.unregister()


### PR DESCRIPTION
The endpoint was receiving duplicate messages if it had registered multiple subscribers on the same topic. When replacing an entry in the dictionary, we need to unregister it.

Tested by modifying the Ros-Unity Integration tutorial script to register a subscriber on Start, and running it multiple times.