### PR TITLE
Use only one connection for all publishers

### DIFF
--- a/src/ros_tcp_endpoint/server.py
+++ b/src/ros_tcp_endpoint/server.py
@@ -43,13 +43,16 @@ class TcpServer:
 
         unity_machine_ip = rospy.get_param("/UNITY_IP", '')
         unity_machine_port = rospy.get_param("/UNITY_SERVER_PORT", 5005)
-        self.unity_tcp_sender = UnityTcpSender(unity_machine_ip, unity_machine_port)
+        self.unity_tcp_sender = UnityTcpSender(self, unity_machine_ip, unity_machine_port)
 
         self.node_name = node_name
         self.source_destination_dict = {}
         self.buffer_size = buffer_size
         self.connections = connections
         self.syscommands = SysCommands(self)
+        self.keep_connections = False
+        self.timeout_in_seconds = 5.0
+        
 
     def start(self):
         server_thread = threading.Thread(target=self.listen_loop)
@@ -132,6 +135,11 @@ class SysCommands:
             self.tcp_server.source_destination_dict[topic].unregister()
         
         self.tcp_server.source_destination_dict[topic] = RosPublisher(topic, message_class, queue_size=10)
+    
+    def connections_parameters(self, keep_connections, timeout_in_s):
+        self.tcp_server.keep_connections = keep_connections
+        self.tcp_server.timeout_in_seconds = timeout_in_s
+        rospy.loginfo("ConnectionsParameters({}, {}) OK".format(keep_connections, timeout_in_s))
 
 
 def resolve_message_name(name):

--- a/src/ros_tcp_endpoint/tcp_sender.py
+++ b/src/ros_tcp_endpoint/tcp_sender.py
@@ -23,11 +23,12 @@ class UnityTcpSender:
     """
     Connects and sends messages to the server on the Unity side.
     """
-    def __init__(self, unity_ip, unity_port):
+    def __init__(self, tcp_server, unity_ip, unity_port):
         self.unity_ip = unity_ip
         self.unity_port = unity_port
         # if we have a valid IP at this point, it was overridden locally so always use that
         self.ip_is_overridden = (self.unity_ip != '')
+        self.tcp_server = tcp_server
 
     def handshake(self, incoming_ip, data):
         message = UnityHandshake._request_class().deserialize(data)
@@ -55,10 +56,12 @@ class UnityTcpSender:
 
         try:
             s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            s.settimeout(2)
+            s.settimeout(self.tcp_server.timeout_in_seconds)
             s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
             s.connect((self.unity_ip, self.unity_port))
             s.send(serialized_message)
-            s.close()
         except Exception as e:
-            rospy.loginfo("Exception {}".format(e))
+            rospy.loginfo("Exception in tcp_sender {}".format(e))
+        finally:
+            s.close()
+            


### PR DESCRIPTION
Opening a new PR for this feature. I opened the equivalent on the ROS-TCP-Connector
The idea is to open only one connection for all publishers for faster publishing
The Unity client sends the server a service message to activate/deactivate this feature.
It's still possible to open one connection per send.

I thought about opening one connection for all subscribers or one connection per subscriber but that would require to change how data reception is handled because that would need threads for the reception part to prevent message queuing which would not go well with callbacks in my opinion