### PR TITLE
Add logging dependency

### DIFF
--- a/src/ros_tcp_endpoint/server.py
+++ b/src/ros_tcp_endpoint/server.py
@@ -12,10 +12,11 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+import sys
+import json
 import rospy
 import socket
-import json
-import sys
+import logging
 import threading
 import importlib
 
@@ -43,7 +44,7 @@ class TcpServer:
             self.tcp_ip = tcp_ip
         else:
             self.tcp_ip = rospy.get_param("/ROS_IP")
-            
+
         if tcp_port != -1:
             self.tcp_port = tcp_port
         else:
@@ -66,7 +67,7 @@ class TcpServer:
         # Exit the server thread when the main thread terminates
         server_thread.daemon = True
         server_thread.start()
-        
+
     def listen_loop(self):
         """
             Creates and binds sockets using TCP variables then listens for incoming connections.
@@ -122,7 +123,7 @@ class SysCommands:
             return
 
         rospy.loginfo("RegisterSubscriber({}, {}) OK".format(topic, message_class))
-        
+
         if topic in self.tcp_server.source_destination_dict:
             self.tcp_server.source_destination_dict[topic].unregister()
 
@@ -140,10 +141,10 @@ class SysCommands:
             return
 
         rospy.loginfo("RegisterPublisher({}, {}) OK".format(topic, message_class))
-        
+
         if topic in self.tcp_server.source_destination_dict:
             self.tcp_server.source_destination_dict[topic].unregister()
-        
+
         self.tcp_server.source_destination_dict[topic] = RosPublisher(topic, message_class, queue_size=10)
 
 


### PR DESCRIPTION
Completing #18 with import of dependency `import logging`

to solve the error message 
```bash
Traceback (most recent call last):
  File "/home/flip/workspaces/syr_ws/src/hcps_ros/unity_ros_bridge/src/ros_tcp_endpoint/server.py", line 85, in listen_loop
    (conn, (ip, port)) = tcp_server.accept()
  File "/usr/local/python/python3.7/lib/python3.7/socket.py", line 212, in accept
    fd, addr = self._accept()
socket.timeout: timed out

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/python/python3.7/lib/python3.7/threading.py", line 926, in _bootstrap_inner
    self.run()
  File "/usr/local/python/python3.7/lib/python3.7/threading.py", line 870, in run
    self._target(*self._args, **self._kwargs)
  File "/home/flip/workspaces/syr_ws/src/hcps_ros/unity_ros_bridge/src/ros_tcp_endpoint/server.py", line 89, in listen_loop
    logging.exception("ros_tcp_endpoint.TcpServer: socket timeout")
NameError: name 'logging' is not defined
```