### PR TITLE
Changing yamato host flavor to large

### DIFF
--- a/.yamato/yamato-config.yml
+++ b/.yamato/yamato-config.yml
@@ -2,7 +2,7 @@ name: Endpoint Unit Tests
 agent:
     type: Unity::VM
     image: robotics/ci-ubuntu20:latest
-    flavor: i1.medium
+    flavor: i1.large
 commands:
     - source /opt/ros/noetic/setup.bash && echo "ROS_DISTRO == $ROS_DISTRO" &&
         cd .. && mkdir -p catkin_ws/src && cp -r ./ROS-TCP-Endpoint catkin_ws/src &&


### PR DESCRIPTION
To support testing with a Unity binary on the same image, the cloud host needs to be changed from medium to large. 