### PR TITLE
Amanda/read chunks

### DIFF
--- a/src/ros_tcp_endpoint/server.py
+++ b/src/ros_tcp_endpoint/server.py
@@ -31,7 +31,7 @@ class TcpServer:
     Initializes ROS node and TCP server.
     """
 
-    def __init__(self, node_name, buffer_size=1024, connections=10, tcp_ip="", tcp_port=-1):
+    def __init__(self, node_name, buffer_size=1024, connections=10, tcp_ip="", tcp_port=-1, timeout=10):
         """
         Initializes ROS node and class variables.
 
@@ -52,7 +52,7 @@ class TcpServer:
 
         unity_machine_ip = rospy.get_param("/UNITY_IP", '')
         unity_machine_port = rospy.get_param("/UNITY_SERVER_PORT", 5005)
-        self.unity_tcp_sender = UnityTcpSender(unity_machine_ip, unity_machine_port)
+        self.unity_tcp_sender = UnityTcpSender(unity_machine_ip, unity_machine_port, timeout)
 
         self.node_name = node_name
         self.source_destination_dict = {}

--- a/src/ros_tcp_endpoint/tcp_sender.py
+++ b/src/ros_tcp_endpoint/tcp_sender.py
@@ -23,11 +23,12 @@ class UnityTcpSender:
     """
     Connects and sends messages to the server on the Unity side.
     """
-    def __init__(self, unity_ip, unity_port):
+    def __init__(self, unity_ip, unity_port, timeout):
         self.unity_ip = unity_ip
         self.unity_port = unity_port
         # if we have a valid IP at this point, it was overridden locally so always use that
         self.ip_is_overridden = (self.unity_ip != '')
+        self.timeout = timeout
 
     def handshake(self, incoming_ip, data):
         message = UnityHandshake._request_class().deserialize(data)
@@ -55,7 +56,7 @@ class UnityTcpSender:
 
         try:
             s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            s.settimeout(10)
+            s.settimeout(self.timeout)
             s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
             s.connect((self.unity_ip, self.unity_port))
             s.sendall(serialized_message)
@@ -72,7 +73,7 @@ class UnityTcpSender:
 
         try:
             s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            s.settimeout(10)
+            s.settimeout(self.timeout)
             s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
             s.connect((self.unity_ip, self.unity_port))
             s.sendall(serialized_message)

--- a/src/ros_tcp_endpoint/tcp_sender.py
+++ b/src/ros_tcp_endpoint/tcp_sender.py
@@ -58,7 +58,7 @@ class UnityTcpSender:
             s.settimeout(2)
             s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
             s.connect((self.unity_ip, self.unity_port))
-            s.send(serialized_message)
+            s.sendall(serialized_message)
             s.close()
         except Exception as e:
             rospy.loginfo("Exception {}".format(e))
@@ -75,7 +75,7 @@ class UnityTcpSender:
             s.settimeout(2)
             s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
             s.connect((self.unity_ip, self.unity_port))
-            s.send(serialized_message)
+            s.sendall(serialized_message)
 
             destination, data = ClientThread.read_message(s)
 

--- a/src/ros_tcp_endpoint/tcp_sender.py
+++ b/src/ros_tcp_endpoint/tcp_sender.py
@@ -55,7 +55,7 @@ class UnityTcpSender:
 
         try:
             s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            s.settimeout(2)
+            s.settimeout(10)
             s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
             s.connect((self.unity_ip, self.unity_port))
             s.sendall(serialized_message)
@@ -72,7 +72,7 @@ class UnityTcpSender:
 
         try:
             s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            s.settimeout(2)
+            s.settimeout(10)
             s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
             s.connect((self.unity_ip, self.unity_port))
             s.sendall(serialized_message)
@@ -85,3 +85,4 @@ class UnityTcpSender:
             return response
         except Exception as e:
             rospy.loginfo("Exception {}".format(e))
+            


### PR DESCRIPTION
Re: [https://github.com/Unity-Technologies/Unity-Robotics-Hub/issues/101](https://github.com/Unity-Technologies/Unity-Robotics-Hub/issues/101)

- `send` -> `sendall`, sends entire message buffer if possible
- Increase default timeout, especially for image streams