### PR TITLE
Fix sending response to unity service

### DIFF
--- a/src/ros_tcp_endpoint/client.py
+++ b/src/ros_tcp_endpoint/client.py
@@ -189,7 +189,7 @@ class ClientThread(threading.Thread):
                         continue                        
                     else:
                         ros_communicator = self.tcp_server.source_destination_dict[srv_message.topic]
-                        response = ros_communicator.send(data)
+                        response = ros_communicator.send(srv_message.payload)
                         if not response:
                             error_msg = "No response data from service '{}'!".format(srv_message.topic)
                             self.tcp_server.send_unity_error(error_msg)


### PR DESCRIPTION
## Proposed change(s)

Fixed the message being sent back to the Unity. 

### Useful links (GitHub issues, JIRA tickets, forum threads, etc.)

Provide any relevant links here.

### Types of change(s)

- [X] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update
- [ ] Other (please describe)

## Testing and Verification

Tested with the Nyrio one pick and place tutorial quick demo. 

### Test Configuration:
- Unity Version: Unity 2020.2.4f1]
- Unity machine OS + version: Mac OS 11.3 Big Sur
- ROS machine OS + version: [e.g. Ubuntu 18.04, ROS Noetic]
- ROS–Unity communication: Docker

## Checklist
- [x] Ensured this PR is up-to-date with the `dev` branch
- [x] Created this PR to target the `dev` branch
- [x] Followed the style guidelines as described in the [Contribution Guidelines](../CONTRIBUTING.md)
- [ ] Added tests that prove my fix is effective or that my feature works
- [x] Updated the documentation as appropriate - Not applicable

## Other comments