### PR TITLE
Fixing package name in endpoint launch file

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -8,13 +8,6 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v2
-            - run: |
-                - echo $PATH
-                - pwd
             - uses: actions/setup-python@v2
               with:
                   python-version: 3.7.x
-            - run: |
-                  - echo $PATH
-                  - pwd
-            - uses: pre-commit/action@v2.0.3

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -8,7 +8,13 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v2
+            - run: |
+                - echo $PATH
+                - pwd
             - uses: actions/setup-python@v2
               with:
                   python-version: 3.7.x
+            - run: |
+                  - echo $PATH
+                  - pwd
             - uses: pre-commit/action@v2.0.3

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -11,4 +11,4 @@ jobs:
             - uses: actions/setup-python@v2
               with:
                   python-version: 3.7.x
-            - uses: pre-commit/action@v2.0.0
+            - uses: pre-commit/action@v2.0.3

--- a/launch/endpoint.py
+++ b/launch/endpoint.py
@@ -4,7 +4,7 @@ from launch_ros.actions import Node
 def generate_launch_description():
     return LaunchDescription([
         Node(
-            package='ros2_tcp_endpoint',
+            package='ros_tcp_endpoint',
             executable='default_server_endpoint',
             emulate_tty=True,
             parameters=[


### PR DESCRIPTION
## Proposed change(s)

The endpoint launch file is trying to launch `ros2_tcp_endpoint`, but the package has been renamed to just `ros_tcp_endpoint`.  Correcting the typo in the launch file.

### Types of change(s)

- [x] Bug fix

## Testing and Verification

Launched after fixing without getting `PackageNotFoundError`
