### PR TITLE
Fixing package name in endpoint launch file

### DIFF
--- a/launch/endpoint.py
+++ b/launch/endpoint.py
@@ -4,7 +4,7 @@ from launch_ros.actions import Node
 def generate_launch_description():
     return LaunchDescription([
         Node(
-            package='ros2_tcp_endpoint',
+            package='ros_tcp_endpoint',
             executable='default_server_endpoint',
             emulate_tty=True,
             parameters=[


### PR DESCRIPTION
## Proposed change(s)

The endpoint launch file is trying to launch `ros2_tcp_endpoint`, but the package has been renamed to just `ros_tcp_endpoint`.  Correcting the typo in the launch file.

### Types of change(s)

- [x] Bug fix

## Testing and Verification

Launched after fixing without getting `PackageNotFoundError`
