### PR TITLE
Fixing rosparam names in default endpoint launch file.

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -11,4 +11,3 @@ jobs:
             - uses: actions/setup-python@v2
               with:
                   python-version: 3.7.x
-            - uses: pre-commit/action@v2.0.0

--- a/launch/endpoint.py
+++ b/launch/endpoint.py
@@ -4,7 +4,7 @@ from launch_ros.actions import Node
 def generate_launch_description():
     return LaunchDescription([
         Node(
-            package='ros2_tcp_endpoint',
+            package='ros_tcp_endpoint',
             executable='default_server_endpoint',
             emulate_tty=True,
             parameters=[

--- a/launch/endpoint.py
+++ b/launch/endpoint.py
@@ -1,6 +1,7 @@
 from launch import LaunchDescription
 from launch_ros.actions import Node
 
+
 def generate_launch_description():
     return LaunchDescription([
         Node(
@@ -8,8 +9,8 @@ def generate_launch_description():
             executable='default_server_endpoint',
             emulate_tty=True,
             parameters=[
-                {'/ROS_IP': '0.0.0.0'},
-                {'/ROS_TCP_PORT': 10000},
+                {'ROS_IP': '0.0.0.0'},
+                {'ROS_TCP_PORT': 10000},
             ],
         ),
     ])


### PR DESCRIPTION
## Proposed change(s)

The rosparams specified in `endpoint.py` used the old ROS1 `/` prefix, but those cause the parameters to be silently ignored in ROS2.  Removed the prefix so the `TCPServer` node appropriately reads the parameter overrides from rosparam instead of the defaults declared in `server.py`. Added some log prints to make it a little clearer which code path is being taken to determine final parameter assignment. 

This branch also contains the other fix, cherry-picked from the `ROS2` branch because I mistakenly merged it there instead of here. Some PEP-8 auto-formatting snuck in as well.

### Types of change(s)

- [x] Bug fix


## Testing and Verification

Gave each parameter assignment a descriptive value like `LAUNCH` and `SERVER` to see which was getting assigned. With `/ROS_IP` in the launch file, the server starts with "IP" `SERVER`. With `ROS_IP` in the file instead, it correctly uses the `LAUNCH` override.

## Checklist
- [x] Ensured this PR is up-to-date with the `dev` branch
- [x] Created this PR to target the `dev` branch
- [x] Followed the style guidelines as described in the [Contribution Guidelines](https://github.com/Unity-Technologies/ROS-TCP-Endpoint/blob/main/CONTRIBUTING.md)