### PR TITLE
Remove /msg/ from type

### DIFF
--- a/ros_tcp_endpoint/tcp_sender.py
+++ b/ros_tcp_endpoint/tcp_sender.py
@@ -125,7 +125,7 @@ class UnityTcpSender:
             topic_list = SysCommand_TopicsResponse()
             topics_and_types = self.tcp_server.get_topic_names_and_types()
             topic_list.topics = [item[0] for item in topics_and_types]
-            topic_list.types = [item[1] for item in topics_and_types]
+            topic_list.types = [item[1][0].replace("/msg/", "/") for item in topics_and_types]
             serialized_bytes = ClientThread.serialize_command("__topic_list", topic_list)
             self.queue.put(serialized_bytes)
 

--- a/ros_tcp_endpoint/tcp_sender.py
+++ b/ros_tcp_endpoint/tcp_sender.py
@@ -125,7 +125,10 @@ class UnityTcpSender:
             topic_list = SysCommand_TopicsResponse()
             topics_and_types = self.tcp_server.get_topic_names_and_types()
             topic_list.topics = [item[0] for item in topics_and_types]
-            topic_list.types = [item[1][0].replace("/msg/", "/") for item in topics_and_types]
+            if isinstance(topics_and_types[0][1], str):
+                topic_list.types = [item[1].replace("/msg/", "/") for item in topics_and_types]
+            else:
+                topic_list.types = [item[1][0].replace("/msg/", "/") for item in topics_and_types]
             serialized_bytes = ClientThread.serialize_command("__topic_list", topic_list)
             self.queue.put(serialized_bytes)
 


### PR DESCRIPTION
## Proposed change(s)

- Parse types as a list of strings rather than a list of lists for ROS2 (formatting appears to have changed between ROS1/2)
- (for ROS2), remove `/msg/` from middle of type name, e.g. geometry_msgs/msg/Point -> geometry_msgs/Point

### Types of change(s)

- [x] Bug fix

## Testing and Verification

### Test Configuration:
- Unity Version: [e.g. Unity 2020.2.0f1]: 2020.3.11
- Unity machine OS + version: [e.g. Windows 10]: MacOS 10.15.7
- ROS machine OS + version: [e.g. Ubuntu 18.04, ROS Noetic]: Ubuntu 20.04, Foxy
- ROS–Unity communication: [e.g. Docker]: VirtualBox

## Checklist
- [x] Ensured this PR is up-to-date with the `ROS2` branch
- [x] Created this PR to target the `ROS2` branch
- [x] Followed the style guidelines as described in the [Contribution Guidelines](https://github.com/Unity-Technologies/ROS-TCP-Endpoint/blob/main/CONTRIBUTING.md)

## Other comments