### PR TITLE
Stale issue handler

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -2,7 +2,7 @@ name: 'Stale issue handler'
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '0 17 * * *' # 17:00 UTC; 10:00 PDT
 
 permissions:
   issues: write
@@ -19,6 +19,7 @@ jobs:
           days-before-stale: 14
           days-before-pr-stale: -1
           days-before-close: 14
+          days-before-pr-close: -1
           exempt-issue-labels: 'blocked,must,should,keep,pinned,work-in-progress,request,announcement'
           close-issue-message: 'This issue has been marked stale for 14 days and will now be closed. If this issue is still valid, please ping a maintainer.'
       - name: Print outputs

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -14,11 +14,13 @@ jobs:
       - uses: actions/stale@v4.0.0
         id: stale
         with:
-          stale-issue-message: 'This issue has been marked stale because it has been open for 30 days with no activity. Please remove the Stale label or comment on this issue, or the issue will be automatically closed in 7 days.'
-          days-before-stale: 30
+          stale-issue-label: 'stale'
+          stale-issue-message: 'This issue has been marked stale because it has been open for 14 days with no activity. Please remove the stale label or comment on this issue, or the issue will be automatically closed in the next 14 days.'
+          days-before-stale: 14
           days-before-pr-stale: -1
-          days-before-close: 7
-          exempt-issue-labels: 'blocked,must,should,keep,pinned,work-in-progress'
-          close-issue-message: 'This issue has been marked stale for 7 days and will now be closed.'
+          days-before-close: 14
+          exempt-issue-labels: 'blocked,must,should,keep,pinned,work-in-progress,request,announcement'
+          close-issue-message: 'This issue has been marked stale for 14 days and will now be closed. If this issue is still valid, please ping a maintainer.'
       - name: Print outputs
         run: echo ${{ join(steps.stale.outputs.*, ',') }}
+        

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,0 +1,24 @@
+name: 'Stale issue handler'
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *'
+
+permissions:
+  issues: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v4.0.0
+        id: stale
+        with:
+          stale-issue-message: 'This issue has been marked stale because it has been open for 30 days with no activity. Please remove the Stale label or comment on this issue, or the issue will be automatically closed in 7 days.'
+          days-before-stale: 30
+          days-before-pr-stale: -1
+          days-before-close: 7
+          exempt-issue-labels: 'blocked,must,should,keep,pinned,work-in-progress'
+          close-issue-message: 'This issue has been marked stale for 7 days and will now be closed.'
+      - name: Print outputs
+        run: echo ${{ join(steps.stale.outputs.*, ',') }}

--- a/.yamato/yamato-config.yml
+++ b/.yamato/yamato-config.yml
@@ -1,7 +1,7 @@
 name: Endpoint Unit Tests
 agent:
     type: Unity::VM
-    image: robotics/ci-ubuntu20:latest
+    image: robotics/ci-ubuntu20:v0.1.0-795910
     flavor: i1.large
 commands:
     # run unit tests and save test results in /home/bokken/build/output/Unity-Technologies/ROS-TCP-Endpoint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## Unreleased
 
+Add the [Close Stale Issues](https://github.com/marketplace/actions/close-stale-issues) action
+
 ### Upgrade Notes
 
 ### Known Issues


### PR DESCRIPTION
## Proposed change(s)

Adds a github action to automatically tag and close out stale issues. Tested on a private repository with shortened times (1 day/stale, 2 day/close). Will be added to other managed repositories when this PR is approved.

![Screen Shot 2021-08-16 at 9 24 26 AM](https://user-images.githubusercontent.com/31416491/129589102-887b9a70-fd46-43eb-8515-28c1f429e897.png)


### Useful links (GitHub issues, JIRA tickets, forum threads, etc.)

- [close-stale-issues](https://github.com/marketplace/actions/close-stale-issues)
- [AIRO-654](https://jira.unity3d.com/browse/AIRO-654)

### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update
- [x] Other (please describe): Github Action

## Testing and Verification

N/A

## Checklist
- [x] Ensured this PR is up-to-date with the `dev` branch
- [x] Created this PR to target the `dev` branch
- [ ] ~~Followed the style guidelines as described in the [Contribution Guidelines](https://github.com/Unity-Technologies/ROS-TCP-Endpoint/blob/main/CONTRIBUTING.md)~~
- [ ] ~~Added tests that prove my fix is effective or that my feature works~~
- [ ] Updated the [Changelog](https://github.com/Unity-Technologies/ROS-TCP-Endpoint/blob/dev/CHANGELOG.md) and described changes in the [Unreleased section](https://github.com/Unity-Technologies/ROS-TCP-Endpoint/blob/dev/CHANGELOG.md#unreleased)
- [ ] Updated the documentation as appropriate