### PR TITLE
Exposing publisher queue_size and latch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ### Added
 
+Support for queue_size and latch for publishers. (https://github.com/Unity-Technologies/ROS-TCP-Endpoint/issues/82)
+
 ### Changed
 
 ### Deprecated

--- a/src/ros_tcp_endpoint/publisher.py
+++ b/src/ros_tcp_endpoint/publisher.py
@@ -22,8 +22,7 @@ class RosPublisher(RosSender):
     Class to publish messages to a ROS topic
     """
 
-    # TODO: surface latch functionality
-    def __init__(self, topic, message_class, queue_size=10):
+    def __init__(self, topic, message_class, queue_size=10, latch=False):
         """
 
         Args:
@@ -33,7 +32,7 @@ class RosPublisher(RosSender):
         """
         RosSender.__init__(self)
         self.msg = message_class()
-        self.pub = rospy.Publisher(topic, message_class, queue_size=queue_size)
+        self.pub = rospy.Publisher(topic, message_class, queue_size=queue_size, latch=latch)
 
     def send(self, data):
         """

--- a/src/ros_tcp_endpoint/server.py
+++ b/src/ros_tcp_endpoint/server.py
@@ -141,7 +141,7 @@ class SysCommands:
             topic, message_class, self.tcp_server
         )
 
-    def publish(self, topic, message_name):
+    def publish(self, topic, message_name, queue_size = 10, latch = False):
         if topic == "":
             self.tcp_server.send_unity_error(
                 "Can't publish to a blank topic name! SysCommand.publish({}, {})".format(
@@ -163,7 +163,7 @@ class SysCommands:
             self.tcp_server.source_destination_dict[topic].unregister()
 
         self.tcp_server.source_destination_dict[topic] = RosPublisher(
-            topic, message_class, queue_size=10
+            topic, message_class, queue_size, latch
         )
 
     def ros_service(self, topic, message_name):

--- a/src/ros_tcp_endpoint/server.py
+++ b/src/ros_tcp_endpoint/server.py
@@ -141,7 +141,7 @@ class SysCommands:
             topic, message_class, self.tcp_server
         )
 
-    def publish(self, topic, message_name, queue_size = 10, latch = False):
+    def publish(self, topic, message_name, queue_size=10, latch=False):
         if topic == "":
             self.tcp_server.send_unity_error(
                 "Can't publish to a blank topic name! SysCommand.publish({}, {})".format(


### PR DESCRIPTION
## Proposed change(s)

Complementary with https://github.com/Unity-Technologies/ROS-TCP-Connector/pull/152
This exposes the queue_size and latch functionality for publishers.

### Useful links (GitHub issues, JIRA tickets, forum threads, etc.)

https://github.com/Unity-Technologies/ROS-TCP-Endpoint/issues/82

### Types of change(s)

- [X] New feature

## Testing and Verification

Please describe the tests that you ran to verify your changes. Please also provide instructions, ROS packages, and Unity project files as appropriate so we can reproduce the test environment.

### Test Configuration:
- Unity Version: [e.g. Unity 2021.1.14f1]
- Unity machine OS + version: [e.g. Ubuntu 18.04]
- ROS machine OS + version: [e.g. Ubuntu 18.04, ROS Melodic]
- ROS–Unity communication: N/A

## Checklist
- [X] Ensured this PR is up-to-date with the `dev` branch
- [X] Created this PR to target the `dev` branch
- [X] Followed the style guidelines as described in the [Contribution Guidelines](https://github.com/Unity-Technologies/ROS-TCP-Endpoint/blob/main/CONTRIBUTING.md)
- [ ] Added tests that prove my fix is effective or that my feature works
- [X] Updated the [Changelog](https://github.com/Unity-Technologies/ROS-TCP-Endpoint/blob/dev/CHANGELOG.md) and described changes in the [Unreleased section](https://github.com/Unity-Technologies/ROS-TCP-Endpoint/blob/dev/CHANGELOG.md#unreleased)
- [ ] Updated the documentation as appropriate

## Other comments
Linked to https://github.com/Unity-Technologies/ROS-TCP-Connector/pull/152