### PR TITLE
Improving the performance of the read_message by not splitting the da…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ Add linter, unit tests, and test coverage reporting
 
 ### Changed
 
+Improving the performance of the read_message in client.py, This is done by receiving the entire message all at once instead of reading 1024 byte chunks and stitching them together as you go.
+
 ### Deprecated
 
 ### Removed

--- a/src/ros_tcp_endpoint/client.py
+++ b/src/ros_tcp_endpoint/client.py
@@ -97,16 +97,7 @@ class ClientThread(threading.Thread):
         destination = ClientThread.read_string(conn)
         full_message_size = ClientThread.read_int32(conn)
 
-        while len(data) < full_message_size:
-            # Only grabs max of 1024 bytes TODO: change to TCPServer's buffer_size
-            grab = 1024 if full_message_size - len(data) > 1024 else full_message_size - len(data)
-            packet = ClientThread.recvall(conn, grab)
-
-            if not packet:
-                rospy.logerr("No packets...")
-                break
-
-            data += packet
+        data = ClientThread.recvall(conn, full_message_size)
 
         if full_message_size > 0 and not data:
             rospy.logerr("No data for a message size of {}, breaking!".format(full_message_size))


### PR DESCRIPTION
Improving the performance read_message, see https://github.com/Unity-Technologies/ROS-TCP-Endpoint/issues/89

This is done by receiving the entire message all at once instead of reading 1024 byte chunks and stitching them together as you go.

## Proposed change(s)

Describe the changes made in this PR.

### Useful links (GitHub issues, JIRA tickets, forum threads, etc.)

Provide any relevant links here.

### Types of change(s)

- [X] Performance Enhancement

## Testing and Verification

Test machine: i7 9700k, 32Gb ddr4 2133MHz ram.
So before the change, it took between 3.5ms and 4.9ms to read a message of length 2764858 byes (24-bit 720p uncompressed image message)
After the change, it took between 0.5ms and 1.1ms.
Nice.

### Test Configuration:
- Unity Version: [e.g. Unity 2021.1.14f1]
- Unity machine OS + version: [e.g. Ubuntu 18.04]
- ROS machine OS + version: [e.g. Ubuntu 18.04, ROS Melodic]

## Checklist
- [ ] Ensured this PR is up-to-date with the `dev` branch
- [X] Created this PR to target the `dev` branch
- [X] Followed the style guidelines as described in the [Contribution Guidelines](https://github.com/Unity-Technologies/ROS-TCP-Endpoint/blob/main/CONTRIBUTING.md)
- [ ] Added tests that prove my fix is effective or that my feature works
- [X] Updated the [Changelog](https://github.com/Unity-Technologies/ROS-TCP-Endpoint/blob/dev/CHANGELOG.md) and described changes in the [Unreleased section](https://github.com/Unity-Technologies/ROS-TCP-Endpoint/blob/dev/CHANGELOG.md#unreleased)
- [ ] Updated the documentation as appropriate

## Other comments