### PR TITLE
ROS2 Multiple Types Warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## Unreleased
 
+Added warning message for multiple types on a single ROS2 topic.
+
 ### Upgrade Notes
 
 ### Known Issues

--- a/ros_tcp_endpoint/tcp_sender.py
+++ b/ros_tcp_endpoint/tcp_sender.py
@@ -125,7 +125,7 @@ class UnityTcpSender:
             topic_list = SysCommand_TopicsResponse()
             topics_and_types = self.tcp_server.get_topic_names_and_types()
             topic_list.topics = [item[0] for item in topics_and_types]
-            topic_list.types = [item[1] for item in topics_and_types]
+            topic_list.types = [item[1][0].replace("/msg/", "/") for item in topics_and_types]
             serialized_bytes = ClientThread.serialize_command("__topic_list", topic_list)
             self.queue.put(serialized_bytes)
 

--- a/ros_tcp_endpoint/tcp_sender.py
+++ b/ros_tcp_endpoint/tcp_sender.py
@@ -185,6 +185,7 @@ class UnityTcpSender:
 
     def parse_message_name(self, name):
         try:
+            # Example input string: <class 'std_msgs.msg._string.Metaclass_String'>
             names = (str(type(name))).split(".")
             module_name = names[0][8:]
             class_name = names[-1].split("_")[-1][:-2]


### PR DESCRIPTION
## Proposed change(s)

ROS1's `get_published_topics` returned `[[str, str]]`, but ROS2's `get_topic_names_and_types` returns a `List[Tuple[str, List[str]]]`. As we don't support multiple types per topic, this PR adds a warning message and maintains the original type subscribed.

### Useful links (GitHub issues, JIRA tickets, forum threads, etc.)

- [rospy get_published_topics](http://docs.ros.org/en/melodic/api/rospy/html/rospy-module.html#get_published_topics)
- [rclpy get_topic_names_and_types](https://docs.ros2.org/latest/api/rclpy/api/node.html#rclpy.node.Node.get_topic_names_and_types)
- [AIRO-1101](https://jira.unity3d.com/browse/AIRO-1101)

### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update
- [ ] Other (please describe)

## Testing and Verification

Tested using string, bool, int32 `ros2 topic pub`.

### Test Configuration:
- Unity Version: 2020.3.11
- Unity machine OS + version: MacOS 10.15.7
- ROS machine OS + version: Ubuntu 20.04, Foxy
- ROS–Unity communication: VirtualBox, bridged adapter

## Checklist
- [x] Ensured this PR is up-to-date with the `dev` branch
- [x] Created this PR to target the `dev` branch
- [x] Followed the style guidelines as described in the [Contribution Guidelines](https://github.com/Unity-Technologies/ROS-TCP-Endpoint/blob/main/CONTRIBUTING.md)
- [ ] Added tests that prove my fix is effective or that my feature works
- [x] Updated the [Changelog](https://github.com/Unity-Technologies/ROS-TCP-Endpoint/blob/dev/CHANGELOG.md) and described changes in the [Unreleased section](https://github.com/Unity-Technologies/ROS-TCP-Endpoint/blob/dev/CHANGELOG.md#unreleased)
- [ ] Updated the documentation as appropriate

## Other comments