### PR TITLE
ROS2-Side Updates

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,0 +1,27 @@
+name: 'Stale issue handler'
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 17 * * *' # 17:00 UTC; 10:00 PDT
+
+permissions:
+  issues: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v4.0.0
+        id: stale
+        with:
+          stale-issue-label: 'stale'
+          stale-issue-message: 'This issue has been marked stale because it has been open for 14 days with no activity. Please remove the stale label or comment on this issue, or the issue will be automatically closed in the next 14 days.'
+          days-before-stale: 14
+          days-before-pr-stale: -1
+          days-before-close: 14
+          days-before-pr-close: -1
+          exempt-issue-labels: 'blocked,must,should,keep,pinned,work-in-progress,request,announcement'
+          close-issue-message: 'This issue has been marked stale for 14 days and will now be closed. If this issue is still valid, please ping a maintainer.'
+      - name: Print outputs
+        run: echo ${{ join(steps.stale.outputs.*, ',') }}
+        

--- a/.yamato/yamato-config.yml
+++ b/.yamato/yamato-config.yml
@@ -1,7 +1,7 @@
 name: Endpoint Unit Tests
 agent:
     type: Unity::VM
-    image: robotics/ci-ubuntu20:latest
+    image: robotics/ci-ubuntu20:v0.1.0-795910
     flavor: i1.large
 commands:
     # run unit tests and save test results in /home/bokken/build/output/Unity-Technologies/ROS-TCP-Endpoint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,29 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## Unreleased
 
+Add the [Close Stale Issues](https://github.com/marketplace/actions/close-stale-issues) action
+
 ### Upgrade Notes
+
+### Known Issues
+
+### Added
+
+Support for queue_size and latch for publishers. (https://github.com/Unity-Technologies/ROS-TCP-Endpoint/issues/82)
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+## [0.5.0] - 2021-07-15
+
+### Upgrade Notes
+
+Upgrade the ROS communication to support ROS2 with Unity
 
 ### Known Issues
 
@@ -37,6 +59,8 @@ Add a link to the Robotics forum, and add a config.yml to add a link in the Gith
 Add linter, unit tests, and test coverage reporting
 
 ### Changed
+
+Improving the performance of the read_message in client.py, This is done by receiving the entire message all at once instead of reading 1024 byte chunks and stitching them together as you go.
 
 ### Deprecated
 

--- a/package.xml
+++ b/package.xml
@@ -2,8 +2,10 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ros_tcp_endpoint</name>
-  <version>0.0.1</version>
-  <description>ROS TCP Endpoint Unity Integration (ROS2 version)</description>
+  <version>0.5.0</version>
+  <description>ROS TCP Endpoint Unity Integration (ROS2 version)
+  Acts as the bridge between Unity messages sent via TCP socket and ROS messages.
+  </description>
   <maintainer email="unity-robotics@unity3d.com">Unity Robotics</maintainer>
   <license>Apache 2.0</license>
 

--- a/ros_tcp_endpoint/client.py
+++ b/ros_tcp_endpoint/client.py
@@ -35,7 +35,9 @@ class ClientThread(threading.Thread):
         Set class variables
         Args:
             conn:
-            source_destination_dict: dictionary of destination name to RosCommunicator class
+            tcp_server: server object
+            incoming_ip: connected from this IP address
+            incoming_port: connected from this port
         """
         self.conn = conn
         self.tcp_server = tcp_server
@@ -141,16 +143,16 @@ class ClientThread(threading.Thread):
         return cmd_info + json_info
 
     def send_ros_service_request(self, srv_id, destination, data):
-        if destination not in self.tcp_server.source_destination_dict.keys():
-            error_msg = "Service destination '{}' is not registered! Known topics are: {} ".format(
-                destination, self.tcp_server.source_destination_dict.keys()
+        if destination not in self.tcp_server.ros_services.keys():
+            error_msg = "Service destination '{}' is not registered! Known services are: {} ".format(
+                destination, self.tcp_server.ros_services.keys()
             )
             self.tcp_server.send_unity_error(error_msg)
             self.logerr(error_msg)
             # TODO: send a response to Unity anyway?
             return
         else:
-            ros_communicator = self.tcp_server.source_destination_dict[destination]
+            ros_communicator = self.tcp_server.ros_services[destination]
             service_thread = threading.Thread(
                 target=self.service_call_thread, args=(srv_id, destination, data, ros_communicator)
             )
@@ -177,8 +179,8 @@ class ClientThread(threading.Thread):
 
     def run(self):
         """
-        Read a message and determine where to send it based on the source_destination_dict
-         and destination string. Then send the read message.
+        Receive a message from Unity and determine where to send it based on the publishers table
+         and topic string. Then send the read message.
 
         If there is a response after sending the serialized data, assume it is a
         ROS service response.
@@ -197,6 +199,7 @@ class ClientThread(threading.Thread):
             while not halt_event.is_set():
                 destination, data = self.read_message(self.conn)
 
+                # Process this message that was sent from Unity
                 if self.tcp_server.pending_srv_id is not None:
                     # if we've been told that the next message will be a service request/response, process it as such
                     if self.tcp_server.pending_srv_is_request:
@@ -214,12 +217,12 @@ class ClientThread(threading.Thread):
                 elif destination.startswith("__"):
                     # handle a system command, such as registering new topics
                     self.tcp_server.handle_syscommand(destination, data)
-                elif destination in self.tcp_server.source_destination_dict:
-                    ros_communicator = self.tcp_server.source_destination_dict[destination]
-                    response = ros_communicator.send(data)
+                elif destination in self.tcp_server.publishers:
+                    ros_communicator = self.tcp_server.publishers[destination]
+                    ros_communicator.send(data)
                 else:
-                    error_msg = "Topic '{}' is not registered! Known topics are: {} ".format(
-                        destination, self.tcp_server.source_destination_dict.keys()
+                    error_msg = "Not registered to publish topic '{}'! Valid publish topics are: {} ".format(
+                        destination, self.tcp_server.publishers.keys()
                     )
                     self.tcp_server.send_unity_error(error_msg)
                     self.logerr(error_msg)

--- a/ros_tcp_endpoint/client.py
+++ b/ros_tcp_endpoint/client.py
@@ -143,16 +143,16 @@ class ClientThread(threading.Thread):
         return cmd_info + json_info
 
     def send_ros_service_request(self, srv_id, destination, data):
-        if destination not in self.tcp_server.ros_services.keys():
+        if destination not in self.tcp_server.ros_services_table.keys():
             error_msg = "Service destination '{}' is not registered! Known services are: {} ".format(
-                destination, self.tcp_server.ros_services.keys()
+                destination, self.tcp_server.ros_services_table.keys()
             )
             self.tcp_server.send_unity_error(error_msg)
             self.logerr(error_msg)
             # TODO: send a response to Unity anyway?
             return
         else:
-            ros_communicator = self.tcp_server.ros_services[destination]
+            ros_communicator = self.tcp_server.ros_services_table[destination]
             service_thread = threading.Thread(
                 target=self.service_call_thread, args=(srv_id, destination, data, ros_communicator)
             )
@@ -217,12 +217,12 @@ class ClientThread(threading.Thread):
                 elif destination.startswith("__"):
                     # handle a system command, such as registering new topics
                     self.tcp_server.handle_syscommand(destination, data)
-                elif destination in self.tcp_server.publishers:
-                    ros_communicator = self.tcp_server.publishers[destination]
+                elif destination in self.tcp_server.publishers_table:
+                    ros_communicator = self.tcp_server.publishers_table[destination]
                     ros_communicator.send(data)
                 else:
                     error_msg = "Not registered to publish topic '{}'! Valid publish topics are: {} ".format(
-                        destination, self.tcp_server.publishers.keys()
+                        destination, self.tcp_server.publishers_table.keys()
                     )
                     self.tcp_server.send_unity_error(error_msg)
                     self.logerr(error_msg)

--- a/ros_tcp_endpoint/client.py
+++ b/ros_tcp_endpoint/client.py
@@ -96,16 +96,7 @@ class ClientThread(threading.Thread):
         destination = self.read_string()
         full_message_size = ClientThread.read_int32(conn)
 
-        while len(data) < full_message_size:
-            # Only grabs max of 1024 bytes TODO: change to TCPServer's buffer_size
-            grab = 1024 if full_message_size - len(data) > 1024 else full_message_size - len(data)
-            packet = ClientThread.recvall(conn, grab)
-
-            if not packet:
-                self.logerr("No packets...")
-                break
-
-            data += packet
+        data = ClientThread.recvall(conn, full_message_size)
 
         if full_message_size > 0 and not data:
             self.logerr("No data for a message size of {}, breaking!".format(full_message_size))

--- a/ros_tcp_endpoint/publisher.py
+++ b/ros_tcp_endpoint/publisher.py
@@ -38,7 +38,7 @@ class RosPublisher(RosSender):
         node_name = f"{strippedTopic}_RosPublisher"
         RosSender.__init__(self, node_name)
         self.msg = message_class()
-        self.pub = self.create_publisher(message_class, topic)
+        self.pub = self.create_publisher(message_class, topic, queue_size)
 
     def send(self, data):
         """

--- a/ros_tcp_endpoint/publisher.py
+++ b/ros_tcp_endpoint/publisher.py
@@ -38,7 +38,7 @@ class RosPublisher(RosSender):
         node_name = f"{strippedTopic}_RosPublisher"
         RosSender.__init__(self, node_name)
         self.msg = message_class()
-        self.pub = self.create_publisher(message_class, topic, queue_size)
+        self.pub = self.create_publisher(message_class, topic)
 
     def send(self, data):
         """

--- a/ros_tcp_endpoint/publisher.py
+++ b/ros_tcp_endpoint/publisher.py
@@ -24,8 +24,9 @@ class RosPublisher(RosSender):
     """
     Class to publish messages to a ROS topic
     """
+
     # TODO: surface latch functionality
-    def __init__(self, topic, message_class, queue_size=10):
+    def __init__(self, topic, message_class, queue_size=10, latch=False):
         """
 
         Args:
@@ -33,8 +34,8 @@ class RosPublisher(RosSender):
             message_class: The message class in catkin workspace
             queue_size:    Max number of entries to maintain in an outgoing queue
         """
-        strippedTopic = re.sub('[^A-Za-z0-9_]+', '', topic)
-        node_name = f'{strippedTopic}_RosPublisher'
+        strippedTopic = re.sub("[^A-Za-z0-9_]+", "", topic)
+        node_name = f"{strippedTopic}_RosPublisher"
         RosSender.__init__(self, node_name)
         self.msg = message_class()
         self.pub = self.create_publisher(message_class, topic, queue_size)
@@ -50,8 +51,8 @@ class RosPublisher(RosSender):
         Returns:
             None: Explicitly return None so behaviour can be
         """
-        #message_type = type(self.msg)
-        #message = deserialize_message(data, message_type)
+        # message_type = type(self.msg)
+        # message = deserialize_message(data, message_type)
 
         self.pub.publish(data)
 

--- a/ros_tcp_endpoint/server.py
+++ b/ros_tcp_endpoint/server.py
@@ -58,7 +58,9 @@ class TcpServer(Node):
             self.tcp_ip = self.get_parameter("ROS_IP").get_parameter_value().string_value
 
         if tcp_port:
-            self.get_logger().log("Using ROS_TCP_PORT override from constructor: {}".format(tcp_port))
+            self.get_logger().log(
+                "Using ROS_TCP_PORT override from constructor: {}".format(tcp_port)
+            )
             self.tcp_port = tcp_port
         else:
             self.tcp_port = self.get_parameter("ROS_TCP_PORT").get_parameter_value().integer_value
@@ -162,14 +164,19 @@ class SysCommands:
         self.tcp_server = tcp_server
 
     def subscribe(self, topic, message_name):
-        if topic == '':
+        if topic == "":
             self.tcp_server.send_unity_error(
-                "Can't subscribe to a blank topic name! SysCommand.subscribe({}, {})".format(topic, message_name))
+                "Can't subscribe to a blank topic name! SysCommand.subscribe({}, {})".format(
+                    topic, message_name
+                )
+            )
             return
 
         message_class = self.resolve_message_name(message_name)
         if message_class is None:
-            self.tcp_server.send_unity_error("SysCommand.subscribe - Unknown message class '{}'".format(message_name))
+            self.tcp_server.send_unity_error(
+                "SysCommand.subscribe - Unknown message class '{}'".format(message_name)
+            )
             return
 
         self.tcp_server.unregister_node(topic)
@@ -179,38 +186,53 @@ class SysCommands:
         if self.tcp_server.executor is not None:
             self.tcp_server.executor.add_node(new_subscriber)
 
-        self.tcp_server.get_logger().info("RegisterSubscriber({}, {}) OK".format(topic, message_class))
+        self.tcp_server.get_logger().info(
+            "RegisterSubscriber({}, {}) OK".format(topic, message_class)
+        )
 
-    def publish(self, topic, message_name):
-        if topic == '':
+    def publish(self, topic, message_name, queue_size=10, latch=False):
+        if topic == "":
             self.tcp_server.send_unity_error(
-                "Can't publish to a blank topic name! SysCommand.publish({}, {})".format(topic, message_name))
+                "Can't publish to a blank topic name! SysCommand.publish({}, {})".format(
+                    topic, message_name
+                )
+            )
             return
 
         message_class = self.resolve_message_name(message_name)
         if message_class is None:
-            self.tcp_server.send_unity_error("SysCommand.publish - Unknown message class '{}'".format(message_name))
+            self.tcp_server.send_unity_error(
+                "SysCommand.publish - Unknown message class '{}'".format(message_name)
+            )
             return
 
         self.tcp_server.unregister_node(topic)
 
-        new_publisher = RosPublisher(topic, message_class, queue_size=10)
+        new_publisher = RosPublisher(topic, message_class, queue_size=queue_size, latch=latch)
 
         self.tcp_server.source_destination_dict[topic] = new_publisher
         if self.tcp_server.executor is not None:
             self.tcp_server.executor.add_node(new_publisher)
 
-        self.tcp_server.get_logger().info("RegisterPublisher({}, {}) OK".format(topic, message_class))
+        self.tcp_server.get_logger().info(
+            "RegisterPublisher({}, {}) OK".format(topic, message_class)
+        )
 
     def ros_service(self, topic, message_name):
-        if topic == '':
+        if topic == "":
             self.tcp_server.send_unity_error(
-                "RegisterRosService({}, {}) - Can't register a blank topic name!".format(topic, message_name))
+                "RegisterRosService({}, {}) - Can't register a blank topic name!".format(
+                    topic, message_name
+                )
+            )
             return
         message_class = self.resolve_message_name(message_name, "srv")
         if message_class is None:
             self.tcp_server.send_unity_error(
-                "RegisterRosService({}, {}) - Unknown service class '{}'".format(topic, message_name, message_name))
+                "RegisterRosService({}, {}) - Unknown service class '{}'".format(
+                    topic, message_name, message_name
+                )
+            )
             return
 
         self.tcp_server.unregister_node(topic)
@@ -221,18 +243,26 @@ class SysCommands:
         if self.tcp_server.executor is not None:
             self.tcp_server.executor.add_node(new_service)
 
-        self.tcp_server.get_logger().info("RegisterRosService({}, {}) OK".format(topic, message_class))
+        self.tcp_server.get_logger().info(
+            "RegisterRosService({}, {}) OK".format(topic, message_class)
+        )
 
     def unity_service(self, topic, message_name):
-        if topic == '':
+        if topic == "":
             self.tcp_server.send_unity_error(
-                "RegisterUnityService({}, {}) - Can't register a blank topic name!".format(topic, message_name))
+                "RegisterUnityService({}, {}) - Can't register a blank topic name!".format(
+                    topic, message_name
+                )
+            )
             return
 
         message_class = self.resolve_message_name(message_name, "srv")
         if message_class is None:
             self.tcp_server.send_unity_error(
-                "RegisterUnityService({}, {}) - Unknown service class '{}'".format(topic, message_name, message_name))
+                "RegisterUnityService({}, {}) - Unknown service class '{}'".format(
+                    topic, message_name, message_name
+                )
+            )
             return
 
         self.tcp_server.unregister_node(topic)
@@ -243,7 +273,9 @@ class SysCommands:
         if self.tcp_server.executor is not None:
             self.tcp_server.executor.add_node(new_service)
 
-        self.tcp_server.get_logger().info("RegisterUnityService({}, {}) OK".format(topic, message_class))
+        self.tcp_server.get_logger().info(
+            "RegisterUnityService({}, {}) OK".format(topic, message_class)
+        )
 
     def response(self, srv_id):  # the next message is a service response
         self.tcp_server.pending_srv_id = srv_id
@@ -258,20 +290,25 @@ class SysCommands:
 
     def resolve_message_name(self, name, extension="msg"):
         try:
-            names = name.split('/')
+            names = name.split("/")
             module_name = names[0]
             class_name = names[1]
             importlib.import_module(module_name + "." + extension)
             module = sys.modules[module_name]
             if module is None:
-                self.tcp_server.get_logger().error("Failed to resolve module {}".format(module_name))
+                self.tcp_server.get_logger().error(
+                    "Failed to resolve module {}".format(module_name)
+                )
             module = getattr(module, extension)
             if module is None:
-                self.tcp_server.get_logger().error("Failed to resolve module {}.{}".format(module_name, extension))
+                self.tcp_server.get_logger().error(
+                    "Failed to resolve module {}.{}".format(module_name, extension)
+                )
             module = getattr(module, class_name)
             if module is None:
                 self.tcp_server.get_logger().error(
-                    "Failed to resolve module {}.{}.{}".format(module_name, extension, class_name))
+                    "Failed to resolve module {}.{}.{}".format(module_name, extension, class_name)
+                )
             return module
         except (IndexError, KeyError, AttributeError, ImportError) as e:
             self.tcp_server.get_logger().error("Failed to resolve message name: {}".format(e))

--- a/ros_tcp_endpoint/tcp_sender.py
+++ b/ros_tcp_endpoint/tcp_sender.py
@@ -93,7 +93,6 @@ class UnityTcpSender:
             return None
 
         thread_pauser = ThreadPauser()
-
         with self.srv_lock:
             srv_id = self.next_srv_id
             self.next_srv_id += 1

--- a/ros_tcp_endpoint/tcp_sender.py
+++ b/ros_tcp_endpoint/tcp_sender.py
@@ -119,12 +119,39 @@ class UnityTcpSender:
 
         thread_pauser.resume_with_result(data)
 
+    def get_registered_topic(self, topic):
+        if topic in self.tcp_server.publishers_table:
+            return self.tcp_server.publishers_table[topic]
+        elif topic in self.tcp_server.subscribers_table:
+            return self.tcp_server.subscribers_table[topic]
+        elif topic in self.tcp_server.ros_services_table:
+            return self.tcp_server.ros_services_table[topic]
+        elif topic in self.tcp_server.unity_services_table:
+            return self.tcp_server.unity_services_table[topic]
+        else:
+            return None
+
     def send_topic_list(self):
         if self.queue is not None:
             topic_list = SysCommand_TopicsResponse()
             topics_and_types = self.tcp_server.get_topic_names_and_types()
             topic_list.topics = [item[0] for item in topics_and_types]
-            topic_list.types = [item[1] for item in topics_and_types]
+            for i in topics_and_types:
+                node = self.get_registered_topic(i[0])
+                if (len(i[1]) > 1):
+                    if (node is not None):
+                        self.tcp_server.get_logger().warning(
+                            "Only one message type per topic is supported, but found multiple types for topic {}; maintaining {} as the subscribed type.".format(
+                                i[0],
+                                self.parse_message_name(node.msg),
+                            )
+                        )
+                topic_list.types = [
+                    item[1][0].replace("/msg/", "/")
+                    if (len(item[1]) <= 1)
+                    else self.parse_message_name(node.msg)
+                    for item in topics_and_types
+                ]
             serialized_bytes = ClientThread.serialize_command("__topic_list", topic_list)
             self.queue.put(serialized_bytes)
 
@@ -166,6 +193,17 @@ class UnityTcpSender:
             with self.queue_lock:
                 if self.queue is local_queue:
                     self.queue = None
+
+    def parse_message_name(self, name):
+        try:
+            # Example input string: <class 'std_msgs.msg._string.Metaclass_String'>
+            names = (str(type(name))).split(".")
+            module_name = names[0][8:]
+            class_name = names[-1].split("_")[-1][:-2]
+            return "{}/{}".format(module_name, class_name)
+        except (IndexError, AttributeError, ImportError) as e:
+            self.tcp_server.get_logger().error("Failed to resolve message name: {}".format(e))
+            return None
 
 
 class SysCommand_Log:

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@ import os
 from setuptools import setup
 
 package_name = 'ros_tcp_endpoint'
+share_dir = os.path.join('share', package_name)
 
 setup(
     name=package_name,
@@ -10,8 +11,8 @@ setup(
     packages=[package_name],
     data_files=[
         ('share/ament_index/resource_index/packages', ['resource/' + package_name]),
-        ('share/' + package_name, ['package.xml']),
-        (os.path.join('share', package_name), ['launch/endpoint.py']),
+        (share_dir, ['package.xml']),
+        (os.path.join(share_dir, 'launch'), ['launch/endpoint.py']),
     ],
     install_requires=['setuptools'],
     zip_safe=True,


### PR DESCRIPTION
## Proposed change(s)

Pulling in miscellaneous ROS1 updates into the ROS2dev branch, as well as renaming variables for ROS2 (e.g. `publishers` -> `publishers_table`.

Also, ROS1's get_published_topics returned [[str, str]], but ROS2's get_topic_names_and_types returns a List[Tuple[str, List[str]]]. As we don't support multiple types per topic, this PR adds a warning message and maintains the original type subscribed.

### Useful links (GitHub issues, JIRA tickets, forum threads, etc.)

- [rospy get_published_topics](http://docs.ros.org/en/melodic/api/rospy/html/rospy-module.html#get_published_topics)
- [rclpy get_topic_names_and_types](https://docs.ros2.org/latest/api/rclpy/api/node.html#rclpy.node.Node.get_topic_names_and_types)
- [AIRO-1101](https://jira.unity3d.com/browse/AIRO-1101), [1158](https://jira.unity3d.com/browse/AIRO-1158)

### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update
- [ ] Other (please describe)

## Checklist
- [x] Ensured this PR is up-to-date with the `dev` branch
- [x] Created this PR to target the `dev` branch
- [x] Followed the style guidelines as described in the [Contribution Guidelines](https://github.com/Unity-Technologies/ROS-TCP-Endpoint/blob/main/CONTRIBUTING.md)
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [Changelog](https://github.com/Unity-Technologies/ROS-TCP-Endpoint/blob/dev/CHANGELOG.md) and described changes in the [Unreleased section](https://github.com/Unity-Technologies/ROS-TCP-Endpoint/blob/dev/CHANGELOG.md#unreleased)
- [ ] Updated the documentation as appropriate

## Other comments