### PR TITLE
AIRO-1368 Allow building debian package 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *~
 build
 devel
+venv_tcp_endpoint/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,4 +8,23 @@ find_package(catkin REQUIRED COMPONENTS
 
 catkin_python_setup()
 
-catkin_package(CATKIN_DEPENDS message_runtime )
+catkin_package(CATKIN_DEPENDS message_runtime rospy)
+
+catkin_install_python(PROGRAMS    src/ros_tcp_endpoint/client.py
+                                  src/ros_tcp_endpoint/communication.py
+                                  src/ros_tcp_endpoint/default_server_endpoint.py
+                                  src/ros_tcp_endpoint/exceptions.py
+                                  src/ros_tcp_endpoint/publisher.py
+                                  src/ros_tcp_endpoint/server.py
+                                  src/ros_tcp_endpoint/service.py
+                                  src/ros_tcp_endpoint/subscriber.py
+                                  src/ros_tcp_endpoint/tcp_sender.py
+                                  src/ros_tcp_endpoint/thread_pauser.py
+                                  src/ros_tcp_endpoint/unity_service.py
+                                  src/ros_tcp_endpoint/default_server_endpoint_venv.py
+                                  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)
+
+install(DIRECTORY launch/ DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/launch)
+install(DIRECTORY config/ DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/config)
+install(FILES requirements.txt DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})

--- a/launch/endpoint.launch
+++ b/launch/endpoint.launch
@@ -1,4 +1,13 @@
 <launch>
+
+    <arg name="enable_py_venv" default="false"/>
+
     <rosparam file="$(find ros_tcp_endpoint)/config/params.yaml" command="load"/>
-    <node name="server_endpoint" pkg="ros_tcp_endpoint" type="default_server_endpoint.py" args="--wait" output="screen" respawn="true" />
+
+    <node name="server_endpoint" pkg="ros_tcp_endpoint" type="default_server_endpoint_venv.py" 
+    args="--venv $(find ros_tcp_endpoint)/venv_tcp_endpoint --wait" output="screen" respawn="true" if="$(arg enable_py_venv)"/>
+
+    <node name="server_endpoint" pkg="ros_tcp_endpoint" type="default_server_endpoint.py" 
+    args="--wait" output="screen" respawn="true" unless="$(arg enable_py_venv)"/>
+
 </launch>

--- a/package.xml
+++ b/package.xml
@@ -11,9 +11,13 @@
   <build_depend>rospy</build_depend>
   <build_depend>message_generation</build_depend>
   <build_export_depend>rospy</build_export_depend>
+  
   <exec_depend>rospy</exec_depend>
+  <exec_depend>std_msgs</exec_depend>
+  <exec_depend>python3-pip</exec_depend>
+  <exec_depend>python3-venv</exec_depend>
+  <exec_depend>virtualenv</exec_depend>
   <exec_depend>message_runtime</exec_depend>
-
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>

--- a/postinst
+++ b/postinst
@@ -1,0 +1,33 @@
+#!/bin/bash
+# shellcheck source=/dev/null
+# ## Detect ROS version or if both ROS1 and ROS2 are installed and get the ros path <ros_path>. 
+base_path="/opt/ros"
+package_name="ros_tcp_endpoint"
+ros_path="$(find "$base_path" -maxdepth 1 -mindepth 1 -type d | tr " " "\n" )"
+venv_name="venv_tcp_endpoint"
+
+n_distros="$(wc -l <<< "$ros_path")"
+
+if [ "$n_distros" -gt "1" ]; then
+    echo "Multiple ros distros founds"
+    valid="0"
+    while [ "$valid" == "0" ]
+    do
+        echo -e "$(ls /opt/ros)\n"
+        echo "Please Insert ROS 1 distro name from the above list to perform installation: "
+        read -r ros_distro
+        for distro in /opt/ros/*; do if [ "$(basename "$distro")" == "$ros_distro" ]; then valid="1"; ros_path="$distro"; fi; done
+    done
+    echo "Package $package_name will be installed on the ros $ros_distro distro in $ros_path"
+fi
+
+cd "$ros_path"/share/"$package_name" || { echo "Error looking for package installation dir in postinstallation"; exit 1; }
+
+echo "Setting up python virtual environment... "
+python3 -m venv "$venv_name" > /dev/null
+sudo chown -R "$(whoami)" "$venv_name"
+source "$venv_name"/bin/activate
+pip3 install --upgrade pip &> /dev/null
+pip3 install wheel &> /dev/null
+pip3 install -r requirements.txt --no-cache-dir &> /dev/null
+deactivate

--- a/postrm
+++ b/postrm
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+if [ "$1" == "remove" ]; then ## Execute only when apt remove executed, not with purge(it includes remove) or upgrade
+
+    # ## Detect ROS version or if both ROS1 and ROS2 are installed and get the ros path <ros_path>.
+    base_path="/opt/ros"
+    package_name="ros_tcp_endpoint"
+    ros_path="$(find "$base_path" -maxdepth 1 -mindepth 1 -type d | tr " " "\n")"
+
+    n_distros="$(wc -l <<<"$ros_path")"
+
+    if [ "$n_distros" -gt "1" ]; then
+        echo "Multiple ros distros founds"
+        valid="0"
+        while [ "$valid" == "0" ]; do
+            echo -e "$(ls /opt/ros)\n"
+            echo "Please Insert ROS 1 distro name from the above list to perform installation: "
+            read -r ros_distro
+            for distro in /opt/ros/*; do if [ "$(basename "$distro")" == "$ros_distro" ]; then
+                valid="1"
+                ros_path="$distro"
+            fi; done
+        done
+        echo "Package $package_name will be removed from the ros $ros_distro distro in $ros_path"
+    fi
+
+    echo "Removing virtual enviroment files..."
+    sudo rm -rf "$ros_path"/share/"$package_name"
+    echo "Virtual enviroment removed"
+
+fi

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 black
 pre-commit
 pytest-cov
+rospkg

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 ## ! DO NOT MANUALLY INVOKE THIS setup.py, USE CATKIN INSTEAD
 
-from setuptools import setup
+from distutils.core import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 # fetch values from package.xml

--- a/src/ros_tcp_endpoint/default_server_endpoint_venv.py
+++ b/src/ros_tcp_endpoint/default_server_endpoint_venv.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+
+import os
+import subprocess
+import sys
+from time import sleep
+
+def is_venv():
+    return (hasattr(sys, 'real_prefix') or
+            (hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix))
+
+arg='--venv'
+args = sys.argv[1:]
+
+path_to_venv = args[args.index(arg) + 1].rstrip('/')
+
+if not is_venv():
+    python_bin = path_to_venv + "/bin/python"
+else:
+    python_bin = sys.executable
+
+dirname, filename = os.path.split(os.path.abspath(__file__))
+script_file = dirname + "/default_server_endpoint.py"
+
+try:
+    s = subprocess.Popen([python_bin, script_file] + args)
+    return_node = s.wait()
+    exit(return_node)
+
+except KeyboardInterrupt:
+
+    while s.poll() is None:
+        sleep(5)
+
+    return_node = s.wait()
+    exit(return_node)

--- a/src/ros_tcp_endpoint/default_server_endpoint_venv.py
+++ b/src/ros_tcp_endpoint/default_server_endpoint_venv.py
@@ -6,13 +6,14 @@ import sys
 from time import sleep
 
 def is_venv():
-    return (hasattr(sys, 'real_prefix') or
-            (hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix))
+    return hasattr(sys, "real_prefix") or (
+        hasattr(sys, "base_prefix") and sys.base_prefix != sys.prefix
+    )
 
-arg='--venv'
+arg = "--venv"
 args = sys.argv[1:]
 
-path_to_venv = args[args.index(arg) + 1].rstrip('/')
+path_to_venv = args[args.index(arg) + 1].rstrip("/")
 
 if not is_venv():
     python_bin = path_to_venv + "/bin/python"


### PR DESCRIPTION

## Proposed change(s)

This change includes all necessary changes to allow creating a debian .deb package with tools like python-bloom and run the inside python scripts with and without a python virtual environment. 

- Debian maintainer script files: A postinst and postrm has been added to allow creating and removing the python virtual environment in the ros package path using the dependencies listed in the requirements.txt
- CMakeLists: Added installs commandas for python programs, launch, config and requirements.txt files
- endpoint.launch: Added argument to allow users choose to run the package with or without the virtual environment. Useful for users that download the source and run it without a virtual environment. *false by default* 
- package.xml: Added extra execution depends
- requirements.txt
### Useful links 

Related github issue:
#99 

### Types of change(s)

- [ ] Bug fix
- [x] New feature
- [ ] Code refactor
- [ ] Documentation update
- [ ] Other (please describe)

## Testing and Verification

Please describe the tests that you ran to verify your changes. Please also provide instructions, ROS packages, and Unity project files as appropriate so we can reproduce the test environment.

The debian has been generated, installed, updated, removed and purged with the expected behavior. It has also been ran with and without the virtual environment

### Test Configuration:

- ROS machine OS + version: [Ubuntu 20.04, ROS Noetic]
Debian package created with the help of aun auxiliary script  [generate_debian_pkgs.sh](https://github.com/robotics-upo/rosdistro/blob/master/generate_debian_pkgs.sh) this helper script only adds some features to standard ros package python-bloom
Clone the package in the src/ folder of a clean workspace and:

```bash
cd <CLEAN_WS>
wget https://raw.githubusercontent.com/robotics-upo/rosdistro/master/generate_debian_pkgs.sh
sudo chmod +x generate_debian_pkgs.sh
./generate_debian_pkgs.sh --output_folder=$(pwd) --workspace_folder=$(pwd)
```

Now the debian should be created in the workspace root. To install it:
```bash
sudo dpkg -i ros-noetic-ros-tcp-endpoint_0.6.0-0focal_amd64.deb
```

To test it make sure you have not sourced your catkin workspace where the package is also downloaded (It has preference over the installed version). So if its sourced, unsource it (maybe you need also to run ```rospack profile``` to detect new installed package) and check that everything is working for both modes, with and without virtual environment:

```bash
roslaunch ros_tcp_endpoint endpoint.launch enable_py_venv:=true
```
or without python virtual environment (default behavior, as it is the current one in the dev branch)

```bash
roslaunch ros_tcp_endpoint endpoint.launch 
```

## Checklist
- [x] Ensured this PR is up-to-date with the `dev` branch
- [x] Created this PR to target the `dev` branch
- [x] Followed the style guidelines as described in the [Contribution Guidelines](https://github.com/Unity-Technologies/ROS-TCP-Endpoint/blob/main/CONTRIBUTING.md)
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [Changelog](https://github.com/Unity-Technologies/ROS-TCP-Endpoint/blob/dev/CHANGELOG.md) and described changes in the [Unreleased section](https://github.com/Unity-Technologies/ROS-TCP-Endpoint/blob/dev/CHANGELOG.md#unreleased)
- [ ] Updated the documentation as appropriate
- [x] Debian maintainer scripts (postinst, postrm) verified with [shellcheck](https://www.shellcheck.net/)
## Other comments