### PR TITLE
AIRO-618 Activating more Yamato features

### DIFF
--- a/.yamato/yamato-config.yml
+++ b/.yamato/yamato-config.yml
@@ -4,8 +4,8 @@ agent:
     image: robotics/ci-ubuntu20:v0.1.0-795910
     flavor: i1.large
 variables:
-  # Coverage measured as a ratio (out of 1.0)
-  COVERAGE_EXPECTED: 0.3
+  # Coverage measured as a percentage (out of 100) 
+  COVERAGE_EXPECTED: 30
 commands:
     # run unit tests and save test results in /home/bokken/build/output/Unity-Technologies/ROS-TCP-Endpoint
     - command: |
@@ -18,8 +18,8 @@ commands:
     - command: |
         linecoverage=$(head -2 test-results/coverage.xml | grep -Eo 'line-rate="[0-9]+([.][0-9]+)?"' | grep -Eo "[0-9]+([.][0-9]+)?")
         echo "Line coverage: $linecoverage"
-        if (( $(echo "$linecoverage < $COVERAGE_EXPECTED" | bc -l) ));
-        then echo "ERROR: Code Coverage is under threshold of $COVERAGE_EXPECTED" && exit 1
+        if (( $(echo "$linecoverage * 100.0 < $COVERAGE_EXPECTED" | bc -l) ));
+        then echo "ERROR: Code Coverage is under threshold of $COVERAGE_EXPECTED%" && exit 1
         fi
 triggers:
     cancel_old_ci: true

--- a/.yamato/yamato-config.yml
+++ b/.yamato/yamato-config.yml
@@ -3,6 +3,9 @@ agent:
     type: Unity::VM
     image: robotics/ci-ubuntu20:v0.1.0-795910
     flavor: i1.large
+variables:
+  # Coverage measured as a ratio (out of 1.0)
+  COVERAGE_EXPECTED: 0.3
 commands:
     # run unit tests and save test results in /home/bokken/build/output/Unity-Technologies/ROS-TCP-Endpoint
     - command: |
@@ -15,14 +18,14 @@ commands:
     - command: |
         linecoverage=$(head -2 test-results/coverage.xml | grep -Eo 'line-rate="[0-9]+([.][0-9]+)?"' | grep -Eo "[0-9]+([.][0-9]+)?")
         echo "Line coverage: $linecoverage"
-        if (( $(echo "$linecoverage < 0.3" | bc -l) )); then exit 1; fi
+        if (( $(echo "$linecoverage < $COVERAGE_EXPECTED" | bc -l) ));
+        then echo "ERROR: Code Coverage is under threshold of $COVERAGE_EXPECTED" && exit 1
+        fi
 triggers:
     cancel_old_ci: true
     expression: |
-        (pull_request.target eq "main"  AND
-        NOT pull_request.push.changes.all match "**/*.md") OR
-        (pull_request.target eq "dev" AND
-        NOT pull_request.push.changes.all match "**/*.md")
+        (pull_request.target eq "main" OR push.branch eq "main" OR pull_request.target eq "dev" OR push.branch eq "dev")
+        AND NOT pull_request.push.changes.all match "**/*.md"
 artifacts:
     logs:
         paths:


### PR DESCRIPTION
## Proposed change(s)

Previously we only tested PRs pre-merge, but those checks don't show up in our commit history, which is very useful to have when looking for breaks in dev or main's history. This PR changes the trigger logic to execute post-merge as well. This change also adds an error message when the code coverage check fails

### Useful links (GitHub issues, JIRA tickets, forum threads, etc.)
https://jira.unity3d.com/browse/AIRO-620
https://jira.unity3d.com/browse/AIRO-618

### Types of change(s)

- [x] Other (please describe)

## Testing and Verification

Ironically this can't be tested without merging it to dev.

## Checklist
- [x] Ensured this PR is up-to-date with the `dev` branch
- [x] Created this PR to target the `dev` branch
- [x] Followed the style guidelines as described in the [Contribution Guidelines](https://github.com/Unity-Technologies/ROS-TCP-Connector/blob/main/CONTRIBUTING.md)
- [ ] Updated the [Changelog](https://github.com/Unity-Technologies/ROS-TCP-Connector/blob/dev/com.unity.robotics.ros-tcp-connector/CHANGELOG.md) and described changes in the [Unreleased section](https://github.com/Unity-Technologies/ROS-TCP-Connector/blob/dev/com.unity.robotics.ros-tcp-connector/CHANGELOG.md#unreleased)