### PR TITLE
Fix/python3 install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ### Added
 
+Support for python3 (ROS Noetic) installs by adding `catkin_install_python` to CMakeLists
+
 ### Changed
 
 ### Deprecated

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,3 +9,8 @@ find_package(catkin REQUIRED COMPONENTS
 catkin_python_setup()
 
 catkin_package(CATKIN_DEPENDS message_runtime )
+
+catkin_install_python(PROGRAMS
+  src/ros_tcp_endpoint/default_server_endpoint.py
+  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)


### PR DESCRIPTION
## Proposed change(s)

Added catkin_install_python in CMakeLists to fix compatibility with Python3 installations

### Useful links (GitHub issues, JIRA tickets, forum threads, etc.)

[Provide any relevant links here.](http://docs.ros.org/en/noetic/api/catkin/html/howto/format2/installing_python.html)

### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update
- [ ] Other (please describe)

## Testing and Verification

Running the ROS node before this change results in errors such as `no module named yaml` because of a Python version mismatch.

Running with this change succesfully starts the ROS node.

### Test Configuration:
- ROS machine OS + version: [e.g. Ubuntu 18.04, ROS Noetic]

## Checklist
- [x] Ensured this PR is up-to-date with the `dev` branch
- [x] Created this PR to target the `dev` branch
- [x] Followed the style guidelines as described in the [Contribution Guidelines](https://github.com/Unity-Technologies/ROS-TCP-Endpoint/blob/main/CONTRIBUTING.md)
- [ ] Added tests that prove my fix is effective or that my feature works
- [x] Updated the [Changelog](https://github.com/Unity-Technologies/ROS-TCP-Endpoint/blob/dev/CHANGELOG.md) and described changes in the [Unreleased section](https://github.com/Unity-Technologies/ROS-TCP-Endpoint/blob/dev/CHANGELOG.md#unreleased)
- [x] Updated the documentation as appropriate

## Other comments