### PR TITLE
AIRO-1707 Implement latching in Publisher

### DIFF
--- a/ros_tcp_endpoint/publisher.py
+++ b/ros_tcp_endpoint/publisher.py
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-import rclpy
+from rclpy.qos import QoSProfile, QoSDurabilityPolicy
 import re
 
 from rclpy.serialization import deserialize_message
@@ -25,7 +25,6 @@ class RosPublisher(RosSender):
     Class to publish messages to a ROS topic
     """
 
-    # TODO: surface latch functionality
     def __init__(self, topic, message_class, queue_size=10, latch=False):
         """
 
@@ -38,7 +37,12 @@ class RosPublisher(RosSender):
         node_name = f"{strippedTopic}_RosPublisher"
         RosSender.__init__(self, node_name)
         self.msg = message_class()
-        self.pub = self.create_publisher(message_class, topic, queue_size)
+
+        qos_profile = QoSProfile(depth=queue_size)
+        if latch:
+            qos_profile.durability = QoSDurabilityPolicy.RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL
+
+        self.pub = self.create_publisher(message_class, topic, qos_profile)
 
     def send(self, data):
         """


### PR DESCRIPTION
## Proposed change(s)

Resolves TODO in code, by reading `latch` parameter and setting QoS accordingly. 

### Types of change(s)

- [ ] Bug fix
- [x] New feature
- [ ] Code refactor
- [ ] Documentation update
- [ ] Other (please describe)

## Testing and Verification

I created a publisher in Unity with latch=true
```
        ros.RegisterPublisher<OccupancyGridMsg>("static_map", 1, true); // queue_size=1, latch=true
        static_map = getOccupancyGrid();
        static_map.header.stamp = new TimeStamp(Clock.time);
        ros.Publish("static_map", static_map);
```

Without the fix, a latched subscriber will not recieve the message if it joins after the message is first published. 

### Test Configuration:
- Unity Version: 2021.1.12f1
- Unity machine Ubuntu 20.04
- ROS machine OS + version: Ubuntu 20.04 / Foxy
- ROS–Unity communication: From source?

## Checklist
- [x] Ensured this PR is up-to-date with the `dev` branch
- [x] Created this PR to target the `dev` branch
- [x] Followed the style guidelines as described in the [Contribution Guidelines](https://github.com/Unity-Technologies/ROS-TCP-Endpoint/blob/main/CONTRIBUTING.md)
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [Changelog](https://github.com/Unity-Technologies/ROS-TCP-Endpoint/blob/dev/CHANGELOG.md) and described changes in the [Unreleased section](https://github.com/Unity-Technologies/ROS-TCP-Endpoint/blob/dev/CHANGELOG.md#unreleased)
- [ ] Updated the documentation as appropriate

## Other comments