### PR TITLE
AIRO-1685 Add log error for invalid message length

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ test-results/
 *~
 build
 devel
+.vscode/

--- a/ros_tcp_endpoint/server.py
+++ b/ros_tcp_endpoint/server.py
@@ -319,6 +319,11 @@ class SysCommands:
 
     def resolve_message_name(self, name, extension="msg"):
         try:
+            if len(name) < 1:
+                self.tcp_server.logerr(
+                    "Failed to resolve empty message name; if message is being registered before Start(), please specify ROS message name, or move registration to Start()."
+                )
+                return None
             names = name.split("/")
             module_name = names[0]
             class_name = names[1]


### PR DESCRIPTION
## Proposed change(s)

Add log error for invalid message length

### Useful links (GitHub issues, JIRA tickets, forum threads, etc.)

https://github.com/Unity-Technologies/ROS-TCP-Connector/pull/260

https://github.com/Unity-Technologies/ROS-TCP-Endpoint/pull/136

## Checklist
- [x] Ensured this PR is up-to-date with the `dev` branch
- [x] Created this PR to target the `dev` branch
- [x] Followed the style guidelines as described in the [Contribution Guidelines](https://github.com/Unity-Technologies/ROS-TCP-Endpoint/blob/main/CONTRIBUTING.md)