### PR TITLE
[CI] ROS2 - Use pinned version of mac image

### DIFF
--- a/.yamato/sonar.yml
+++ b/.yamato/sonar.yml
@@ -1,7 +1,7 @@
 name: Sonarqube Standard Scan
 agent:
     type: Unity::metal::macmini
-    image: package-ci/mac
+    image: package-ci/mac:v1.8.1-822785
     flavor: m1.mac
 variables:
     SONARQUBE_PROJECT_KEY: ai-robotics-endpoint-ros2


### PR DESCRIPTION
## Proposed change(s)

(copied from #138)

We are going to stop allowing people to target a Bokken image without specifying a tag.
Only a handful of people are using it, and it gets in the way of using sourcegraph insights to estimate usage.
Currently, no tag equals using the stable version of the image.
I used a pinned version instead of stable because that tag is also going to disappear and I want to prevent you from having to do another maintenance in a few months.

### Useful links (GitHub issues, JIRA tickets, forum threads, etc.)

JIRA Ticket https://jira.unity3d.com/browse/DSBKN-1034
Image version in the Bokken image catalogue http://images.bokken.cloud:8000/#/image/package-ci/mac/673349491555729414

ROS2 version of #138 

### Types of change(s)

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update
- [x] Other (please describe) CI fix

## Testing and Verification

Run affected CI pipeline on Yamato.

### Test Configuration: Not applicable (CI environment)

## Checklist 
- [x] Ensured this PR is up-to-date with the `dev` branch
- [x] Created this PR to target the `dev` branch
- [x] Followed the style guidelines as described in the [Contribution Guidelines](https://github.com/Unity-Technologies/ROS-TCP-Endpoint/blob/main/CONTRIBUTING.md)