### PR TITLE
fixed dash-separated user warning

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
 [develop]
-script-dir=$base/lib/ros_tcp_endpoint
+script_dir=$base/lib/ros_tcp_endpoint
 [install]
-install-scripts=$base/lib/ros_tcp_endpoint
+install_scripts=$base/lib/ros_tcp_endpoint


### PR DESCRIPTION
## Proposed change(s)

When building the code I got the following warnings:

> UserWarning: Usage of dash-separated 'script-dir' will not be supported in future versions. Please use the underscore name 'script_dir' instead

> UserWarning: Usage of dash-separated 'install-scripts' will not be supported in future versions. Please use the underscore name 'install_scripts' instead

### Types of change(s)

- [x] Bug fix

## Testing and Verification

I did as the user warning said and simply replaced the dash with an underscore.

### Test Configuration:
- Unity machine OS + version: [Ubuntu 20.04]
- ROS machine OS + version: [Ubuntu 20.04, ROS2 Foxy]

## Checklist
- [x] Ensured this PR is up-to-date with the `dev` branch
- [x] Created this PR to target the `dev` branch
- [x] Followed the style guidelines as described in the [Contribution Guidelines](https://github.com/Unity-Technologies/ROS-TCP-Endpoint/blob/main/CONTRIBUTING.md)
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [Changelog](https://github.com/Unity-Technologies/ROS-TCP-Endpoint/blob/dev/CHANGELOG.md) and described changes in the [Unreleased section](https://github.com/Unity-Technologies/ROS-TCP-Endpoint/blob/dev/CHANGELOG.md#unreleased)
- [ ] Updated the documentation as appropriate

## Other comments