### PR TITLE
Add "remove_subscriber"

### DIFF
--- a/src/ros_tcp_endpoint/server.py
+++ b/src/ros_tcp_endpoint/server.py
@@ -283,3 +283,9 @@ class SysCommands:
         except (IndexError, KeyError, AttributeError, ImportError) as e:
             self.tcp_server.logerr("Failed to resolve message name: {}".format(e))
             return None
+
+    def remove_subscriber(self, topic):
+        old_subscriber = self.tcp_server.subscribers_table[topic]
+        old_subscriber.unregister()
+        del self.tcp_server.subscribers_table[topic]
+        self.tcp_server.loginfo("UnregisterSubscriber({}) OK".format(topic))


### PR DESCRIPTION
## Proposed change(s)

Add missing "remove_subscriber" function which is called by `UnsubscribeAll()` implemented here:

https://github.com/Unity-Technologies/ROS-TCP-Connector/pull/196/files#diff-fbf6c2f2a1a7feb6b363ab04f47f6ea0f3ceefa1c75138f030c78deb84aab60fR161-R167

https://github.com/Unity-Technologies/ROS-TCP-Connector/pull/196/files#diff-05890041157eb5ce2693b5736e8d08f41110bea75e83609a2b4f97eeb26ce7a4R369-R388

### Useful links (GitHub issues, JIRA tickets, forum threads, etc.)

Provide any relevant links here.

### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update
- [ ] Other (please describe)

## Testing and Verification
### Test Configuration:
- Unity Version: Unity 2020.3.30f1
- Unity machine OS + version: Ubuntu 18.04
- ROS machine OS + version: Ubuntu 18.04, ROS Noetic
- ROS–Unity communication: Native

### Procedure:

1. launch ros_tcp_endpoint and teleop_twist_keyboard

```
roslaunch ros_tcp_endpoint endpoint.launch
```

```
rosrun teleop_twist_keyboard teleop_twist_keyboard.py
```


I think you can use `rostopic pub` instead of `teleop_twist_keyboard`.


2. use `UnsubscribeAll();` in Unity (with ROS-TCP-Connector v0.7.0) like this:

```csharp
using UnityEngine;
using Unity.Robotics.ROSTCPConnector;
using TwistMsg = RosMessageTypes.Geometry.TwistMsg;

public class CmdVelSubscriber : MonoBehaviour
{
    [SerializeField] string rosTopicName = "cmd_vel";
    [SerializeField] bool isDebugMode = true;
    [SerializeField] bool stopSubscribing = false;
    bool isSubscribing = true;

    void Start()
    {
        ROSConnection.GetOrCreateInstance().Subscribe<TwistMsg>(rosTopicName, CmdVelUpdate);
    }

    void CmdVelUpdate(TwistMsg twistMessage)
    {
        if (isDebugMode)
        {
            Debug.Log(twistMessage);
        }
    }
    void Update()
    {
        if (stopSubscribing){
            if (isSubscribing)
            {
                RosTopicState state = ROSConnection.GetOrCreateInstance().GetTopic(rosTopicName);
                state.UnsubscribeAll();
                isSubscribing = false;
            }
        }
    }
}
```

ref: https://github.com/unity3d-jp/Unity-ROS-MobileRobot-UI-Tutorial/blob/main/MobileRobotUITutorialProject/Assets/Scripts/CmdVelSubscriber.cs

Without this patch, the ROS-TCP-Connector and the ROS-TCP-Endpoint shows the following error.

Unity

```
Connection to 127.0.0.1:10000 failed - System.IO.IOException: Unable to write data to the transport connection: The socket has been shut down. ---> System.Net.Sockets.SocketException: The socket has been shut down
  at System.Net.Sockets.Socket.Send (System.Byte[] buffer, System.Int32 offset, System.Int32 size, System.Net.Sockets.SocketFlags socketFlags) [0x00016] in <0463b2ef957545c0a51b42f372cd4fbb>:0 
  at System.Net.Sockets.NetworkStream.Write (System.Byte[] buffer, System.Int32 offset, System.Int32 size) [0x0009b] in <0463b2ef957545c0a51b42f372cd4fbb>:0 
   --- End of inner exception stack trace ---
  at System.Net.Sockets.NetworkStream.Write (System.Byte[] buffer, System.Int32 offset, System.Int32 size) [0x000e2] in <0463b2ef957545c0a51b42f372cd4fbb>:0 
  at Unity.Robotics.ROSTCPConnector.SysCommandSender.SendInternal (Unity.Robotics.ROSTCPConnector.MessageGeneration.MessageSerializer m_MessageSerializer, System.IO.Stream stream) [0x00016] in /path/to/the/project/Library/PackageCache/com.unity.robotics.ros-tcp-connector@c27f00c6cf/Runtime/TcpConnector/OutgoingMessageSender.cs:39 
  at Unity.Robotics.ROSTCPConnector.ROSConnection+<ConnectionThread>d__115.MoveNext () [0x001e9] in /path/to/the/project/Library/PackageCache/com.unity.robotics.ros-tcp-connector@c27f00c6cf/Runtime/TcpConnector/ROSConnection.cs:824 
UnityEngine.Debug:Log (object)
Unity.Robotics.ROSTCPConnector.ROSConnection/<ConnectionThread>d__115:MoveNext () (at Library/PackageCache/com.unity.robotics.ros-tcp-connector@c27f00c6cf/Runtime/TcpConnector/ROSConnection.cs:854)
System.Threading._ThreadPoolWaitCallback:PerformWaitCallback ()
```

ROS

```
[INFO] [1653965598.855207]: Disconnected from 127.0.0.1
Exception in thread Thread-26:
Traceback (most recent call last):
  File "/usr/lib/python2.7/threading.py", line 801, in __bootstrap_inner
    self.run()
  File "/path/to/the/catkin_ws/src/ros_tcp_endpoint/src/ros_tcp_endpoint/client.py", line 222, in run
    self.tcp_server.handle_syscommand(destination, data)
  File "/path/to/the/catkin_ws/src/ros_tcp_endpoint/src/ros_tcp_endpoint/server.py", line 112, in handle_syscommand
    function = getattr(self.syscommands, topic[2:])
AttributeError: SysCommands instance has no attribute 'remove_subscriber'
```

After applying this patch, the Unity shows no error and the following message shows in the ROS console.

```
[INFO] [1653966364.216153]: UnregisterSubscriber(cmd_vel) OK
```


## Checklist
- [x] Ensured this PR is up-to-date with the `dev` branch
- [x] Created this PR to target the `dev` branch
- [x] Followed the style guidelines as described in the [Contribution Guidelines](https://github.com/Unity-Technologies/ROS-TCP-Endpoint/blob/main/CONTRIBUTING.md)
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [Changelog](https://github.com/Unity-Technologies/ROS-TCP-Endpoint/blob/dev/CHANGELOG.md) and described changes in the [Unreleased section](https://github.com/Unity-Technologies/ROS-TCP-Endpoint/blob/dev/CHANGELOG.md#unreleased)
- [ ] Updated the documentation as appropriate

## Other comments