### PR TITLE
Add missing unsubscribe support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ### Fixed
 
+Implement missing `__remove_subscriber` sys. command to unsubscribe TCP-connector from a topic
+
 ## [0.7.0] - 2022-02-01
 
 ### Added

--- a/src/ros_tcp_endpoint/server.py
+++ b/src/ros_tcp_endpoint/server.py
@@ -160,6 +160,12 @@ class SysCommands:
 
         self.tcp_server.loginfo("RegisterSubscriber({}, {}) OK".format(topic, message_class))
 
+    def remove_subscriber(self, topic):
+        node = self.tcp_server.subscribers_table.get(topic)
+        if node is not None:
+            self.tcp_server.unregister_node(node)
+        self.tcp_server.subscribers_table.pop(topic)
+
     def publish(self, topic, message_name, queue_size=10, latch=False):
         if topic == "":
             self.tcp_server.send_unity_error(


### PR DESCRIPTION
Currenlty unsubscribing from a topic is not possible. Unity side actually has unsubscribe method, but ROS side does not implement that functionality. As a result, calling unsubscribe causes the `AttributeError: 'SysCommands' object has no attribute 'remove_subscriber'` exception.

This PR adds the missing method `remove_subscriber`, which unregisters ROS subscriber so new messages are not sent to Unity anymore.

This bug is reported in [this issue](https://github.com/Unity-Technologies/Unity-Robotics-Hub/issues/311) on [Unity-Robotics-Hub](https://github.com/Unity-Technologies/Unity-Robotics-Hub) repository.

[Here](https://github.com/Unity-Technologies/Unity-Robotics-Hub/issues/311#issuecomment-1067290122)  is described the call stack, that causes the exception, in more detail:

> If Unity script calls the [Unsubscribe](https://github.com/Unity-Technologies/ROS-TCP-Connector/blob/c27f00c6cf750d2d0564349b3039d19aa3925e7c/com.unity.robotics.ros-tcp-connector/Runtime/TcpConnector/ROSConnection.cs#L203) function, which calls [UnsubscribeAll](https://github.com/Unity-Technologies/ROS-TCP-Connector/blob/c27f00c6cf750d2d0564349b3039d19aa3925e7c/com.unity.robotics.ros-tcp-connector/Runtime/TcpConnector/RosTopicState.cs#L166). This calls [SendSubscriberUnregistration](https://github.com/Unity-Technologies/ROS-TCP-Connector/blob/c27f00c6cf750d2d0564349b3039d19aa3925e7c/com.unity.robotics.ros-tcp-connector/Runtime/TcpConnector/ROSConnection.cs#L396), which sends the [remove_subscriber](https://github.com/Unity-Technologies/ROS-TCP-Connector/blob/c27f00c6cf750d2d0564349b3039d19aa3925e7c/com.unity.robotics.ros-tcp-connector/Runtime/TcpConnector/SysCommand.cs#L21) command. That results in the following error:
> 
> ```
> Exception in thread Thread-2:
> Traceback (most recent call last):
>   File "/usr/lib/python3.8/threading.py", line 932, in _bootstrap_inner
>     self.run()
>   File "ros_tcp_endpoint/client.py", line 225, in run
>     self.tcp_server.handle_syscommand(destination, data)
>   File "ros_tcp_endpoint/lib/python3.8/site-packages/ros_tcp_endpoint/server.py", line 114, in handle_syscommand
>     function = getattr(self.syscommands, topic[2:])
> AttributeError: 'SysCommands' object has no attribute 'remove_subscriber'
> ```



