### PR TITLE
Add ROS2 Action support to ROS-TCP-Endpoint

### DIFF
--- a/ros_tcp_endpoint/action_client.py
+++ b/ros_tcp_endpoint/action_client.py
@@ -1,0 +1,193 @@
+#  Copyright 2020 Unity Technologies
+#  Copyright 2026 gd-ros-tcp-connector contributors
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""
+Thin wrapper around ``rclpy.action.ActionClient`` that bridges the
+ROS-TCP-Endpoint wire protocol to real ROS 2 Action servers.
+
+A plain ``rclpy.create_client()`` cannot discover Action endpoints
+because they use a different DDS endpoint kind / QoS profile than
+regular services.  This module solves the problem by creating a real
+``ActionClient`` and exposing ``send_goal`` / ``get_result`` /
+``cancel_goal`` as methods the TCP server can call with serialized
+CDR payloads.
+"""
+
+import re
+import threading
+
+import rclpy
+from rclpy.action import ActionClient
+from rclpy.serialization import deserialize_message, serialize_message
+
+from .communication import RosSender
+
+
+class RosActionClient(RosSender):
+    """
+    Manages one ``rclpy.action.ActionClient`` for a single action name.
+    """
+
+    def __init__(self, action_name, action_class, tcp_server):
+        stripped = re.sub("[^A-Za-z0-9_]+", "", action_name)
+        node_name = f"{stripped}_RosActionClient"
+        RosSender.__init__(self, node_name)
+
+        self.action_name = action_name
+        self.action_class = action_class
+        self.tcp_server = tcp_server
+
+        self._action_client = ActionClient(self, action_class, action_name)
+        self._goal_handles = {}  # goal_uuid_bytes -> ClientGoalHandle
+        self._goal_handles_lock = threading.Lock()
+
+    def send_goal(self, goal_data):
+        """Send a goal. *goal_data* is CDR-serialized Goal body bytes.
+
+        Returns the CDR-serialized SendGoal_Response (accepted + stamp),
+        or None on failure.
+        """
+        import time
+
+        goal_msg = deserialize_message(
+            goal_data, self.action_class.Goal)
+
+        # The node is already added to the TcpServer's
+        # MultiThreadedExecutor, so DDS discovery proceeds on the
+        # executor thread. We just poll server_is_ready() here; do NOT
+        # call rclpy.spin_once(self) because the executor already owns
+        # this node and double-spinning causes deadlocks.
+        server_ready = False
+        for _ in range(100):  # 100 x 0.1s = 10s max
+            if self._action_client.server_is_ready():
+                server_ready = True
+                break
+            time.sleep(0.1)
+
+        if not server_ready:
+            self.get_logger().error(
+                f"Action server {self.action_name} not available "
+                f"(waited 10s — is the server running?)")
+            return None
+
+        # Do NOT pass feedback_callback here. The client subscribes to the
+        # feedback topic via __subscribe, which creates a RosSubscriber
+        # that forwards feedback through the normal topic path. If we
+        # ALSO forwarded feedback from _on_feedback, every feedback
+        # would arrive twice on the client side.
+        future = self._action_client.send_goal_async(goal_msg)
+
+        # Wait for the send_goal future. Again, the executor is
+        # spinning on another thread, so we just poll the future.
+        for _ in range(100):  # 10s max
+            if future.done():
+                break
+            time.sleep(0.1)
+        goal_handle = future.result()
+        if goal_handle is None:
+            return None
+
+        # Build a SendGoal_Response to send back to the client.
+        # rclpy's ActionClient generates its own UUID for the goal
+        # (ignoring any UUID we might have set), so we need to tell
+        # the client which UUID was actually used. We prepend the 16-byte
+        # UUID to the CDR-serialized SendGoal_Response; the client strips
+        # the first 16 bytes before deserializing.
+        response_class = self.action_class.Impl.SendGoalService.Response
+        resp = response_class()
+        resp.accepted = goal_handle.accepted
+        resp.stamp = goal_handle.stamp if hasattr(goal_handle, 'stamp') else resp.stamp
+
+        goal_uuid = bytes(goal_handle.goal_id.uuid)
+        if goal_handle.accepted:
+            with self._goal_handles_lock:
+                self._goal_handles[goal_uuid] = goal_handle
+
+        return goal_uuid + serialize_message(resp)
+
+    def get_result(self, goal_id_data):
+        """Request the result for a goal. *goal_id_data* is CDR-serialized
+        GetResult_Request bytes (contains the goal UUID).
+
+        Returns CDR-serialized GetResult_Response, or None on failure.
+        """
+        request_class = self.action_class.Impl.GetResultService.Request
+        req = deserialize_message(goal_id_data, request_class)
+
+        key = bytes(req.goal_id.uuid)
+        with self._goal_handles_lock:
+            goal_handle = self._goal_handles.get(key)
+
+        if goal_handle is None:
+            self.get_logger().error(
+                f"get_result: no goal handle for UUID {key.hex()}")
+            return None
+
+        import time
+        result_future = goal_handle.get_result_async()
+        # Poll instead of spin_until_future_complete — executor owns us.
+        for _ in range(3000):  # 300s max
+            if result_future.done():
+                break
+            time.sleep(0.1)
+        result = result_future.result()
+
+        # Clean up the handle.
+        with self._goal_handles_lock:
+            self._goal_handles.pop(key, None)
+
+        if result is None:
+            return None
+
+        # Build GetResult_Response
+        response_class = self.action_class.Impl.GetResultService.Response
+        resp = response_class()
+        resp.status = result.status
+        resp.result = result.result
+        return serialize_message(resp)
+
+    def cancel_goal(self, goal_info_data):
+        """Cancel a goal. *goal_info_data* is CDR-serialized
+        CancelGoal_Request bytes.
+
+        Returns CDR-serialized CancelGoal_Response, or None.
+        """
+        from action_msgs.srv import CancelGoal
+        req = deserialize_message(goal_info_data, CancelGoal.Request)
+
+        key = bytes(req.goal_info.goal_id.uuid)
+        with self._goal_handles_lock:
+            goal_handle = self._goal_handles.get(key)
+
+        if goal_handle is None:
+            self.get_logger().error(
+                f"cancel_goal: no goal handle for UUID {key.hex()}")
+            return None
+
+        import time
+        cancel_future = goal_handle.cancel_goal_async()
+        for _ in range(100):  # 10s max
+            if cancel_future.done():
+                break
+            time.sleep(0.1)
+        cancel_response = cancel_future.result()
+
+        if cancel_response is None:
+            return None
+        return serialize_message(cancel_response)
+
+    def unregister(self):
+        self._action_client.destroy()
+        self.destroy_node()

--- a/ros_tcp_endpoint/action_server.py
+++ b/ros_tcp_endpoint/action_server.py
@@ -1,0 +1,150 @@
+#  Copyright 2020 Unity Technologies
+#  Copyright 2026 gd-ros-tcp-connector contributors
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""
+Bridge a client-implemented Action server through ROS-TCP-Endpoint.
+
+When a ROS 2 action client sends a goal, the execute_callback
+forwards it to the client using the same __request/__response two-frame
+pair that regular unity_service uses. The client computes and sends the
+result back; feedback is pushed from the client via a separate
+__action_publish_feedback syscommand.
+"""
+
+import re
+import threading
+import time
+
+from rclpy.action import ActionServer, CancelResponse, GoalResponse
+from rclpy.serialization import deserialize_message, serialize_message
+
+from .communication import RosSender
+
+
+class RosActionServer(RosSender):
+
+    def __init__(self, action_name, action_class, tcp_server):
+        stripped = re.sub("[^A-Za-z0-9_]+", "", action_name)
+        node_name = f"{stripped}_RosActionServer"
+        RosSender.__init__(self, node_name)
+
+        self.action_name = action_name
+        self.action_class = action_class
+        self.tcp_server = tcp_server
+
+        # goal_uuid bytes -> ServerGoalHandle (for feedback publishing)
+        self._goal_handles = {}
+        self._lock = threading.Lock()
+
+        self._action_server = ActionServer(
+            self,
+            action_class,
+            action_name,
+            execute_callback=self._execute_callback,
+            goal_callback=lambda _: GoalResponse.ACCEPT,
+            cancel_callback=lambda _: CancelResponse.ACCEPT,
+        )
+
+    def _execute_callback(self, goal_handle):
+        """Forward the goal to the client and wait for the result."""
+        goal_uuid = bytes(goal_handle.goal_id.uuid)
+
+        with self._lock:
+            self._goal_handles[goal_uuid] = goal_handle
+
+        # Serialize the Goal body.
+        goal_msg = goal_handle.request
+        goal_cdr = serialize_message(goal_msg)
+
+        # Send the goal to the client using the __request / __response
+        # mechanism. send_unity_service_request blocks until the client
+        # responds. We use the action_name as the topic/destination
+        # so the client.s action server can route it.
+        #
+        # BUT: send_unity_service_request calls deserialize_message
+        # on the response, which needs a rclpy type. We need raw CDR
+        # bytes instead. So we use a raw version.
+        result_cdr = self._send_goal_to_client(goal_uuid, goal_cdr)
+
+        # Clean up.
+        with self._lock:
+            self._goal_handles.pop(goal_uuid, None)
+
+        if result_cdr is None:
+            goal_handle.abort()
+            return self.action_class.Result()
+
+        result_msg = deserialize_message(result_cdr, self.action_class.Result)
+        goal_handle.succeed()
+        return result_msg
+
+    def _send_goal_to_client(self, goal_uuid, goal_cdr):
+        """Send a goal to the client and wait for the result CDR bytes.
+
+        Uses the same ThreadPauser mechanism as send_unity_service_request
+        but works with raw CDR bytes.
+        """
+        from .tcp_sender import ThreadPauser, SysCommand_Service
+
+        sender = self.tcp_server.unity_tcp_sender
+        if sender.queue is None:
+            return None
+
+        thread_pauser = ThreadPauser()
+        with sender.srv_lock:
+            srv_id = sender.next_srv_id
+            sender.next_srv_id += 1
+            sender.services_waiting[srv_id] = thread_pauser
+
+        # Build __request{srv_id} header.
+        from .client import ClientThread
+        command = SysCommand_Service()
+        command.srv_id = srv_id
+        serialized_header = ClientThread.serialize_command("__request", command)
+
+        # Build the data frame: destination = action_name, payload =
+        # 16-byte goal UUID + CDR goal body. the client strips the UUID
+        # to identify which goal this is for.
+        import struct
+        dest_bytes = self.action_name.encode("utf-8")
+        dest_len = len(dest_bytes)
+        payload = goal_uuid + goal_cdr
+        dest_info = struct.pack("<I%ss" % dest_len, dest_len, dest_bytes)
+        msg_length = struct.pack("<I", len(payload))
+        serialized_message = dest_info + msg_length + payload
+
+        sender.queue.put(b"".join([serialized_header, serialized_message]))
+
+        # Block until the client sends __response{srv_id} with the result.
+        thread_pauser.sleep_until_resumed()
+
+        return thread_pauser.result  # raw CDR bytes
+
+    def publish_feedback(self, goal_uuid_bytes, feedback_cdr):
+        """Called when the client sends feedback for an in-progress goal."""
+        with self._lock:
+            goal_handle = self._goal_handles.get(goal_uuid_bytes)
+
+        if goal_handle is None:
+            self.get_logger().warning(
+                f"publish_feedback: no goal handle for {goal_uuid_bytes.hex()}")
+            return
+
+        fb_msg = deserialize_message(feedback_cdr, self.action_class.Feedback)
+        goal_handle.publish_feedback(fb_msg)
+
+    def unregister(self):
+        self._action_server.destroy()
+        self.destroy_node()

--- a/ros_tcp_endpoint/client.py
+++ b/ros_tcp_endpoint/client.py
@@ -159,6 +159,64 @@ class ClientThread(threading.Thread):
             service_thread.daemon = True
             service_thread.start()
 
+    def handle_action_request(self, srv_id, action_name, op, data):
+        """Route an action operation to the RosActionClient."""
+        client = self.tcp_server.action_clients_table.get(action_name)
+        if client is None:
+            error_msg = "Action client '{}' is not registered!".format(action_name)
+            self.tcp_server.send_unity_error(error_msg)
+            self.tcp_server.logerr(error_msg)
+            return
+
+        # Run in a thread to avoid blocking the read loop (action calls
+        # can take seconds to minutes).
+        t = threading.Thread(
+            target=self._action_call_thread,
+            args=(srv_id, action_name, op, data, client),
+            daemon=True)
+        t.start()
+
+    def _action_call_thread(self, srv_id, action_name, op, data, client):
+        """Execute the action operation and send the response back."""
+        response_data = None
+        try:
+            if op == "send_goal":
+                response_data = client.send_goal(data)
+            elif op == "get_result":
+                response_data = client.get_result(data)
+            elif op == "cancel_goal":
+                response_data = client.cancel_goal(data)
+            else:
+                self.tcp_server.logerr(
+                    "Unknown action op '{}' for '{}'".format(op, action_name))
+                return
+        except Exception as e:
+            self.tcp_server.logerr(
+                "Action {} {} failed: {}".format(action_name, op, e))
+            return
+
+        if response_data is None:
+            error_msg = "No response from action {} {}".format(action_name, op)
+            self.tcp_server.send_unity_error(error_msg)
+            self.tcp_server.logerr(error_msg)
+            return
+
+        # Send the CDR-serialized response back to the client. Use the _raw
+        # variant because response_data is already CDR bytes (the
+        # RosActionClient does its own serialize_message internally).
+        self.tcp_server.unity_tcp_sender.send_ros_service_response_raw(
+            srv_id, action_name, response_data)
+
+    def _handle_action_feedback(self, action_name, goal_uuid_hex, data):
+        """Route feedback CDR bytes to the matching RosActionServer."""
+        server = self.tcp_server.action_servers_table.get(action_name)
+        if server is None:
+            self.tcp_server.logerr(
+                "Action server '{}' not registered for feedback".format(action_name))
+            return
+        goal_uuid = bytes.fromhex(goal_uuid_hex)
+        server.publish_feedback(goal_uuid, data)
+
     def service_call_thread(self, srv_id, destination, data, ros_communicator):
         response = ros_communicator.send(data)
 
@@ -193,18 +251,32 @@ class ClientThread(threading.Thread):
             while not halt_event.is_set():
                 destination, data = self.read_message(self.conn)
 
-                # Process this message that was sent from Unity
-                if self.tcp_server.pending_srv_id is not None:
-                    # if we've been told that the next message will be a service request/response, process it as such
-                    if self.tcp_server.pending_srv_is_request:
-                        self.send_ros_service_request(
-                            self.tcp_server.pending_srv_id, destination, data
-                        )
-                    else:
-                        self.tcp_server.send_unity_service_response(
-                            self.tcp_server.pending_srv_id, data
-                        )
+                # Process this message that was sent from Unity.
+
+                # Check for pending action feedback (no srv_id involved).
+                action_op = getattr(self.tcp_server, "pending_action_op", None)
+                if action_op == "publish_feedback":
+                    action_name = self.tcp_server.pending_action_name
+                    goal_uuid_hex = getattr(self.tcp_server, "pending_action_goal_uuid", "")
+                    self.tcp_server.pending_action_op = None
+                    self.tcp_server.pending_action_name = None
+                    self.tcp_server.pending_action_goal_uuid = None
+                    self._handle_action_feedback(action_name, goal_uuid_hex, data)
+                elif self.tcp_server.pending_srv_id is not None:
+                    srv_id = self.tcp_server.pending_srv_id
                     self.tcp_server.pending_srv_id = None
+
+                    # Check if this is an action client request.
+                    action_op2 = getattr(self.tcp_server, "pending_action_op", None)
+                    action_name2 = getattr(self.tcp_server, "pending_action_name", None)
+                    if action_op2 is not None:
+                        self.tcp_server.pending_action_op = None
+                        self.tcp_server.pending_action_name = None
+                        self.handle_action_request(srv_id, action_name2, action_op2, data)
+                    elif self.tcp_server.pending_srv_is_request:
+                        self.send_ros_service_request(srv_id, destination, data)
+                    else:
+                        self.tcp_server.send_unity_service_response(srv_id, data)
                 elif destination == "":
                     # ignore this keepalive message, listen for more
                     pass

--- a/ros_tcp_endpoint/server.py
+++ b/ros_tcp_endpoint/server.py
@@ -30,6 +30,8 @@ from .subscriber import RosSubscriber
 from .publisher import RosPublisher
 from .service import RosService
 from .unity_service import UnityService
+from .action_client import RosActionClient
+from .action_server import RosActionServer
 
 
 class TcpServer(Node):
@@ -70,6 +72,11 @@ class TcpServer(Node):
         self.subscribers_table = {}
         self.ros_services_table = {}
         self.unity_services_table = {}
+        self.action_clients_table = {}
+        self.action_servers_table = {}
+        self.pending_action_op = None
+        self.pending_action_name = None
+        self.pending_action_goal_uuid = None
         self.buffer_size = buffer_size
         self.connections = connections
         self.syscommands = SysCommands(self)
@@ -306,6 +313,111 @@ class SysCommands:
 
         self.tcp_server.loginfo("RegisterUnityService({}, {}) OK".format(topic, message_class))
 
+    def action_client(self, action_name, action_type):
+        """Register a RosActionClient that bridges to a real ROS2 action
+        server.  Unlike ``ros_service``, this creates an
+        ``rclpy.action.ActionClient`` which can discover DDS action
+        endpoints that plain ``create_client()`` cannot see.
+
+        The client sends ``__action_client {action_name, action_type}``
+        once, then uses ``__action_send_goal``, ``__action_get_result``,
+        and ``__action_cancel_goal`` to interact with the server.
+        """
+        if action_name == "":
+            self.tcp_server.send_unity_error(
+                "RegisterActionClient - blank action name!")
+            return
+
+        # Resolve the Action class (e.g. example_interfaces.action.Fibonacci).
+        action_class = self.resolve_message_name(action_type, "action")
+        if action_class is None:
+            self.tcp_server.send_unity_error(
+                "RegisterActionClient({}, {}) - Unknown action class '{}'".format(
+                    action_name, action_type, action_type))
+            return
+
+        old_node = self.tcp_server.action_clients_table.get(action_name)
+        if old_node is not None:
+            self.tcp_server.unregister_node(old_node)
+
+        new_client = RosActionClient(action_name, action_class,
+                                     self.tcp_server.unity_tcp_sender)
+        self.tcp_server.action_clients_table[action_name] = new_client
+        if self.tcp_server.executor is not None:
+            self.tcp_server.executor.add_node(new_client)
+
+        self.tcp_server.loginfo(
+            "RegisterActionClient({}, {}) OK".format(action_name, action_class))
+
+    def action_send_goal(self, action_name, srv_id):
+        """The next frame carries the CDR-serialized Goal body.  We set
+        pending_srv_id so the client thread routes the next payload to
+        our action_client.send_goal, and sends the response back via
+        the normal __response{srv_id} mechanism.
+        """
+        self.tcp_server.pending_srv_id = srv_id
+        self.tcp_server.pending_srv_is_request = True
+        self.tcp_server.pending_action_name = action_name
+        self.tcp_server.pending_action_op = "send_goal"
+
+    def action_get_result(self, action_name, srv_id):
+        """The next frame carries GetResult_Request (just a UUID)."""
+        self.tcp_server.pending_srv_id = srv_id
+        self.tcp_server.pending_srv_is_request = True
+        self.tcp_server.pending_action_name = action_name
+        self.tcp_server.pending_action_op = "get_result"
+
+    def action_cancel_goal(self, action_name, srv_id):
+        """The next frame carries CancelGoal_Request."""
+        self.tcp_server.pending_srv_id = srv_id
+        self.tcp_server.pending_srv_is_request = True
+        self.tcp_server.pending_action_name = action_name
+        self.tcp_server.pending_action_op = "cancel_goal"
+
+    def action_server(self, action_name, action_type):
+        """Register a RosActionServer so the client can implement an action.
+
+        When a ROS 2 action client sends a goal, the endpoint forwards
+        it to the client as a __request/__response pair. The client processes the
+        goal and sends feedback via __action_publish_feedback and the
+        result via __response.
+        """
+        if action_name == "":
+            self.tcp_server.send_unity_error(
+                "RegisterActionServer - blank action name!")
+            return
+
+        action_class = self.resolve_message_name(action_type, "action")
+        if action_class is None:
+            self.tcp_server.send_unity_error(
+                "RegisterActionServer({}, {}) - Unknown action class".format(
+                    action_name, action_type))
+            return
+
+        old_node = self.tcp_server.action_servers_table.get(action_name)
+        if old_node is not None:
+            self.tcp_server.unregister_node(old_node)
+
+        new_server = RosActionServer(action_name, action_class,
+                                     self.tcp_server)
+        self.tcp_server.action_servers_table[action_name] = new_server
+        if self.tcp_server.executor is not None:
+            self.tcp_server.executor.add_node(new_server)
+
+        self.tcp_server.loginfo(
+            "RegisterActionServer({}, {}) OK".format(action_name, action_class))
+
+    def action_publish_feedback(self, action_name, goal_uuid_hex):
+        """The next frame carries CDR-serialized Feedback body.
+
+        We set pending state so the client thread routes the next
+        payload to the matching RosActionServer.publish_feedback().
+        """
+        self.tcp_server.pending_srv_id = None  # not a srv_id response
+        self.tcp_server.pending_action_name = action_name
+        self.tcp_server.pending_action_op = "publish_feedback"
+        self.tcp_server.pending_action_goal_uuid = goal_uuid_hex
+
     def response(self, srv_id):  # the next message is a service response
         self.tcp_server.pending_srv_id = srv_id
         self.tcp_server.pending_srv_is_request = False
@@ -318,6 +430,39 @@ class SysCommands:
         self.tcp_server.unity_tcp_sender.send_topic_list()
 
     def resolve_message_name(self, name, extension="msg"):
+        """Resolve a ROS message/service/action class by name.
+
+        Tries the given extension first (e.g. "msg" or "srv"), then
+        falls back to "action" if the primary lookup fails. This lets
+        clients register Action-generated types (e.g.
+        ``Fibonacci_SendGoal``) via the normal ``__ros_service`` /
+        ``__subscribe`` syscommands without any protocol changes.
+        """
+        result = self._try_resolve_message_name(name, extension)
+        if result is None and extension != "action":
+            result = self._try_resolve_message_name(name, "action")
+        if result is None:
+            self.tcp_server.logerr(
+                "Failed to resolve message name '{}' in extensions '{}' and 'action'".format(
+                    name, extension
+                )
+            )
+        return result
+
+    def _try_resolve_message_name(self, name, extension):
+        """Attempt to import *name* from the *extension* sub-module.
+
+        Returns the class on success, or ``None`` on any failure
+        (without logging — the caller decides whether to report).
+
+        For the ``"action"`` extension, rclpy exposes Action sub-types
+        as nested classes rather than flat module attributes.  For
+        example, ``example_interfaces/Fibonacci_SendGoal_Request`` maps
+        to ``example_interfaces.action.Fibonacci.Impl.SendGoalService.Request``.
+        This method handles the translation automatically so that
+        clients can use the flat ``Package/Action_Suffix`` naming
+        convention over the wire.
+        """
         try:
             names = name.split("/")
             module_name = names[0]
@@ -325,18 +470,85 @@ class SysCommands:
             importlib.import_module(module_name + "." + extension)
             module = sys.modules[module_name]
             if module is None:
-                self.tcp_server.logerr("Failed to resolve module {}".format(module_name))
-            module = getattr(module, extension)
+                return None
+            module = getattr(module, extension, None)
             if module is None:
-                self.tcp_server.logerr(
-                    "Failed to resolve module {}.{}".format(module_name, extension)
-                )
-            module = getattr(module, class_name)
-            if module is None:
-                self.tcp_server.logerr(
-                    "Failed to resolve module {}.{}.{}".format(module_name, extension, class_name)
-                )
-            return module
-        except (IndexError, KeyError, AttributeError, ImportError) as e:
-            self.tcp_server.logerr("Failed to resolve message name: {}".format(e))
+                return None
+
+            # For msg/srv the class sits directly on the sub-module.
+            cls = getattr(module, class_name, None)
+            if cls is not None:
+                return cls
+
+            # For action types, try the nested-class lookup.
+            if extension == "action":
+                cls = self._try_resolve_action_class(module, class_name)
+            return cls
+        except (IndexError, KeyError, AttributeError, ImportError):
+            return None
+
+    @staticmethod
+    def _try_resolve_action_class(action_module, class_name):
+        """Resolve an Action sub-type from its flat wire name.
+
+        rclpy generates Action classes with this nesting structure::
+
+            <ActionModule>.<Action>.Goal
+            <ActionModule>.<Action>.Result
+            <ActionModule>.<Action>.Feedback
+            <ActionModule>.<Action>.Impl.SendGoalService.Request
+            <ActionModule>.<Action>.Impl.SendGoalService.Response
+            <ActionModule>.<Action>.Impl.GetResultService.Request
+            <ActionModule>.<Action>.Impl.GetResultService.Response
+            <ActionModule>.<Action>.Impl.FeedbackMessage
+
+        On the wire the client sends a flat name like
+        ``Fibonacci_SendGoal_Request``.  We split on ``_`` to recover
+        the Action name and the suffix, then walk the nested attrs.
+        """
+        try:
+            # Map flat suffixes to attribute paths inside Action.Impl.
+            # Longest suffixes first so "SendGoal_Request" is tried
+            # before "SendGoal".
+            IMPL_MAP = {
+                "SendGoal_Request":  ["Impl", "SendGoalService", "Request"],
+                "SendGoal_Response": ["Impl", "SendGoalService", "Response"],
+                "GetResult_Request":  ["Impl", "GetResultService", "Request"],
+                "GetResult_Response": ["Impl", "GetResultService", "Response"],
+                "FeedbackMessage":   ["Impl", "FeedbackMessage"],
+                # Service-class lookups (no _Request/_Response suffix).
+                # ros_service resolves the service CLASS, then accesses
+                # .Request / .Response internally.  The service class
+                # itself lives at Action.Impl.{SendGoal,GetResult}Service.
+                "SendGoal":  ["Impl", "SendGoalService"],
+                "GetResult": ["Impl", "GetResultService"],
+            }
+            # Direct sub-class suffixes (no Impl nesting).
+            DIRECT_MAP = {
+                "Goal": "Goal",
+                "Result": "Result",
+                "Feedback": "Feedback",
+            }
+
+            # Try each known suffix, longest first so that
+            # "SendGoal_Request" matches before "Goal".
+            for suffix, path in IMPL_MAP.items():
+                if class_name.endswith("_" + suffix):
+                    action_name = class_name[: -(len(suffix) + 1)]
+                    obj = getattr(action_module, action_name, None)
+                    for attr in path:
+                        if obj is None:
+                            break
+                        obj = getattr(obj, attr, None)
+                    return obj
+
+            for suffix, attr in DIRECT_MAP.items():
+                if class_name.endswith("_" + suffix):
+                    action_name = class_name[: -(len(suffix) + 1)]
+                    obj = getattr(action_module, action_name, None)
+                    if obj is not None:
+                        return getattr(obj, attr, None)
+
+            return None
+        except (AttributeError, TypeError):
             return None

--- a/ros_tcp_endpoint/server.py
+++ b/ros_tcp_endpoint/server.py
@@ -437,7 +437,17 @@ class SysCommands:
         clients register Action-generated types (e.g.
         ``Fibonacci_SendGoal``) via the normal ``__ros_service`` /
         ``__subscribe`` syscommands without any protocol changes.
+
+        Also handles 3-segment names like
+        ``package/action/ClassName`` (which __topic_list may report)
+        by extracting the middle segment as the extension.
         """
+        # Handle 3-segment names: "pkg/msg/Type" or "pkg/action/Type"
+        parts = name.split("/")
+        if len(parts) == 3 and parts[1] in ("msg", "srv", "action"):
+            name = parts[0] + "/" + parts[2]
+            extension = parts[1]
+
         result = self._try_resolve_message_name(name, extension)
         if result is None and extension != "action":
             result = self._try_resolve_message_name(name, "action")

--- a/ros_tcp_endpoint/tcp_sender.py
+++ b/ros_tcp_endpoint/tcp_sender.py
@@ -84,6 +84,24 @@ class UnityTcpSender:
             serialized_message = ClientThread.serialize_message(destination, response)
             self.queue.put(b"".join([serialized_header, serialized_message]))
 
+    def send_ros_service_response_raw(self, srv_id, destination, raw_cdr_bytes):
+        """Like send_ros_service_response but takes already-serialized CDR
+        bytes instead of a rclpy message object. Used by RosActionClient
+        which does its own serialize_message internally."""
+        if self.queue is not None:
+            command = SysCommand_Service()
+            command.srv_id = srv_id
+            serialized_header = ClientThread.serialize_command("__response", command)
+
+            import struct
+            dest_bytes = destination.encode("utf-8")
+            length = len(dest_bytes)
+            dest_info = struct.pack("<I%ss" % length, length, dest_bytes)
+            msg_length = struct.pack("<I", len(raw_cdr_bytes))
+            serialized_message = dest_info + msg_length + raw_cdr_bytes
+
+            self.queue.put(b"".join([serialized_header, serialized_message]))
+
     def send_unity_message(self, topic, message):
         if self.queue is not None:
             serialized_message = ClientThread.serialize_message(topic, message)


### PR DESCRIPTION
## Proposed change(s)

Add ROS2 Action support to ROS-TCP-Endpoint. The stock endpoint cannot bridge ROS2 Actions because rclpy.action.ActionServer/ActionClient use a different DDS endpoint kind than plain services.

### Changes

**resolve_message_name improvements:**
- Falls back to the "action" extension when "msg" or "srv" fails
- Navigates rclpy nested Action class structure (Fibonacci.Impl.SendGoalService.Request etc.) via _try_resolve_action_class
- Adds service-class entries (SendGoal, GetResult) to the suffix map

**Action client protocol (new):**
- RosActionClient class wrapping rclpy.action.ActionClient
- Syscommands: __action_client, __action_send_goal, __action_get_result, __action_cancel_goal
- Futures polled with time.sleep to avoid executor ownership conflicts

**Action server protocol (new):**
- RosActionServer class wrapping rclpy.action.ActionServer
- Goal forwarded to TCP client via existing __request/__response mechanism
- Feedback from client via __action_publish_feedback
- Syscommands: __action_server, __action_publish_feedback

**Additional:**
- send_ros_service_response_raw for pre-serialized CDR bytes
- Feedback deduplication (removed feedback_callback, uses __subscribe path only)

### Types of change(s)

- [ ] Bug fix
- [x] New feature
- [ ] Code refactor
- [ ] Documentation update
- [ ] Other

## Testing and Verification

Tested end-to-end with action_tutorials_interfaces/Fibonacci action:
1. TCP client as action client calling ROS2 fibonacci_action_server: send_goal, feedback, get_result all verified
2. ROS2 `ros2 action send_goal` calling TCP-client-implemented action server: goal received, feedback published, result returned with SUCCEEDED status

### Test Configuration:
- ROS machine OS + version: Ubuntu 22.04, ROS2 Humble
- Endpoint: Built from this branch (main-ros2)
- Action server: `ros2 run action_tutorials_py fibonacci_action_server`

## Checklist
- [x] Ensured this PR is up-to-date with the main-ros2 branch
- [ ] Created this PR to target the dev branch (Note: dev-ros2 has not been updated since 2022; targeting main-ros2 instead)
- [x] Followed the style guidelines as described in the Contribution Guidelines
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the Changelog
- [ ] Updated the documentation as appropriate

## Notes

The main-ros2 and dev-ros2 branches have not been updated since 2022, but the endpoint is still actively used by the community. This PR is offered as a contribution for anyone who needs Action support through the TCP bridge.

The implementation is backwards-compatible. Existing msg/srv lookups are completely unaffected. The action extension fallback only triggers when the primary lookup fails.